### PR TITLE
[WB-29]: Add common-beer-format predicate functions

### DIFF
--- a/.clj-kondo/com.wallbrew/spoon/config.edn
+++ b/.clj-kondo/com.wallbrew/spoon/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {com.wallbrew.spoon.core/when-let+ clojure.core/let}}

--- a/.github/workflows/deploy_to_clojars.yml
+++ b/.github/workflows/deploy_to_clojars.yml
@@ -2,7 +2,7 @@ name: Deploy to Clojars
 
 on:
   workflow_dispatch:
-    
+
 
 jobs:
   deploy:

--- a/.sealog/changes/1-5-0.edn
+++ b/.sealog/changes/1-5-0.edn
@@ -1,0 +1,12 @@
+{:version      {:major 1
+                :minor 5
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["A calculation function to derive the volume of wort at the start of the boil."
+                             "Predicate functions for all `common-beer-format` types."]
+                :changed    ["`com.wallbrew/spoon` is now a production dependency of `brewtility`."]
+                :deprecated []
+                :removed    []
+                :fixed      ["Introduced missing `defn` metadata tags in the `calculation` namespace."]
+                :security   []}
+ :timestamp    "2023-02-13T00:10:04.600775500Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [1.5.0 - 2023-02-13](#150---2023-02-13)
 * [1.4.0 - 2023-02-12](#140---2023-02-12)
 * [1.3.0 - 2023-02-12](#130---2023-02-12)
 * [1.2.0 - 2022-07-10](#120---2022-07-10)
 * [1.1.0 - 2020-08-15](#110---2020-08-15)
 * [1.0.0 - 2020-07-19](#100---2020-07-19)
+
+## 1.5.0 - 2023-02-13
+
+* Added
+  * A calculation function to derive the volume of wort at the start of the boil.
+  * Predicate functions for all `common-beer-format` types.
+* Changed
+  * `com.wallbrew/spoon` is now a production dependency of `brewtility`.
+* Fixed
+  * Introduced missing `defn` metadata tags in the `calculation` namespace.
 
 ## 1.4.0 - 2023-02-12
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The library does provide access to other functions, but those primarily exist in
 - [Calculations](doc/api/calculations.md)
 - [Color](doc/api/color.md)
 - [Precision](doc/api/precision.md)
+- [Predicates](doc/api/predicates.md)
 - [Units of Measure](doc/api/units.md)
 - [Wrapping](doc/api/wrapping.md)
 

--- a/doc/api/predicates.md
+++ b/doc/api/predicates.md
@@ -1,0 +1,8 @@
+# Predicates
+
+While working with beer data, it is frequently necessary to control program logic differently for different types of ingredient.
+For example, calculating the final color of a beer depends on the color of the ingredients in the beer.
+Both in the BeerXML spec, and in industry conventions, malted grains and other fermentables have their colors measured in separate systems.
+For this reason, we need a function to be able to determine if a `common-beer-format` fermentable is a grain or not.
+
+These functions are unique to each `common-beer-format` type, which are individual namespaces in the `brewtility.predicates.*` set.

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -2,11 +2,11 @@
                    ["Changelog" {:file "CHANGELOG.md"}]
                    ["Community" {}
                     ["Contributing" {:file "CONTRIBUTING.md"}]
-                    ["Code of Conduct" {:file "CODE_OF_CONDUCT.md"}]
-                    ["License" {:file "LICENSE"}]]
+                    ["Code of Conduct" {:file "CODE_OF_CONDUCT.md"}]]
                    ["Functionality" {}
                     ["Calculations" {:file "doc/api/calculations.md"}]
                     ["Color" {:file "doc/api/color.md"}]
                     ["Precision" {:file "doc/api/precision.md"}]
+                    ["Predicates" {:file "doc/api/predicates.md"}]
                     ["Units of Measure" {:file "doc/api/units.md"}]
                     ["Wrapping" {:file "doc/api/wrapping.md"}]]]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewtility",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brewtility",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "karma": "^6.3.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brewtility",
-  "version": "1.4.0",
-  "description": "Utility functions for all of your brewing needs",
+  "version": "1.5.0",
+  "description": "Utility functions for all of your brewing needs.",
   "main": "index.js",
   "directories": {
     "test": "test"

--- a/pom.xml
+++ b/pom.xml
@@ -4,23 +4,23 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>brewtility</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
   <name>brewtility</name>
-  <description>Utility functions for all of your brewing needs</description>
+  <description>Utility functions for all of your brewing needs.</description>
   <url>https://github.com/Wall-Brew-Co/brewtility</url>
   <licenses>
     <license>
       <name>MIT</name>
       <url>https://opensource.org/licenses/MIT</url>
       <distribution>repo</distribution>
-      <comments>Same-as all Wall-Brew projects</comments>
+      <comments>Same-as all Wall-Brew projects.</comments>
     </license>
   </licenses>
   <scm>
     <url>https://github.com/Wall-Brew-Co/brewtility</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/brewtility.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/brewtility.git</developerConnection>
-    <tag>161b368204c7bd469bdf76507e5948b6148c23e9</tag>
+    <tag>47bfea691592555cd7be8f910c170d69591be94d</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.wallbrew</groupId>
       <artifactId>spoon</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>com.wallbrew</groupId>
       <artifactId>common-beer-data</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.wallbrew</groupId>
       <artifactId>common-beer-format</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
 (defproject com.wallbrew/brewtility "1.4.0"
-  :description "Utility functions for all of your brewing needs"
+  :description "Utility functions for all of your brewing needs."
   :url "https://github.com/Wall-Brew-Co/brewtility"
   :license {:name         "MIT"
             :url          "https://opensource.org/licenses/MIT"
             :distribution :repo
-            :comments     "Same-as all Wall-Brew projects"}
+            :comments     "Same-as all Wall-Brew projects."}
   :scm {:name "git"
         :url  "https://github.com/Wall-Brew-Co/brewtility"}
-  :dependencies [[com.wallbrew/spoon "1.1.0"]
+  :dependencies [[com.wallbrew/spoon "1.2.1"]
                  [org.clojure/clojure "1.11.1"]
                  [org.clojure/clojurescript "1.11.60" :scope "provided"]]
 
@@ -26,7 +26,7 @@
 
   :profiles {:uberjar {:aot :all}
              :dev     {:dependencies [[com.wallbrew/common-beer-data "1.2.0"]
-                                      [com.wallbrew/common-beer-format "2.2.0"]
+                                      [com.wallbrew/common-beer-format "2.2.1"]
                                       [doo "0.1.11"]]
                        :plugins      [[lein-doo "0.1.11"]]}}
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/brewtility "1.4.0"
+(defproject com.wallbrew/brewtility "1.5.0"
   :description "Utility functions for all of your brewing needs."
   :url "https://github.com/Wall-Brew-Co/brewtility"
   :license {:name         "MIT"

--- a/src/brewtility/calculations.cljc
+++ b/src/brewtility/calculations.cljc
@@ -199,6 +199,7 @@
   (let [reducing-fn (fn [acc h] (+ acc (calculate-ibu-per-hop h batch-size potential-gravity)))]
     (reduce reducing-fn 0 hops)))
 
+
 (defn calculate-equipment-boil-volume
   "Given a `common-beer-format` conforming `equipment`, calculate the volume of the wort at the start of the boil.
    If insufficient data is provided, this function will throw an exception."

--- a/src/brewtility/predicates/equipment.cljc
+++ b/src/brewtility/predicates/equipment.cljc
@@ -1,0 +1,22 @@
+(ns brewtility.predicates.equipment
+  "Predicate functions for [equipment](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/equipment.cljc) maps"
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]})
+
+
+(defn calculated-boil-volume?
+  "A predicate function to determine if an [equipment](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/equipment.cljc) had its boil volume calculated.
+   In the BeerXML spec, this behavior is implicitly falsey.
+   Therefore, if the :calc-boil-volume field is not present, this function will explicitly return false."
+  {:added "1.5"}
+  [equipment]
+  (if (contains? equipment :calc-boil-volume)
+    (:calc-boil-volume equipment)
+    false))

--- a/src/brewtility/predicates/fermentables.cljc
+++ b/src/brewtility/predicates/fermentables.cljc
@@ -1,0 +1,120 @@
+(ns brewtility.predicates.fermentables
+  "Predicate functions for [fermentables](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) maps."
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+(defn add-after-boil?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) was added after the start of the boil.
+   In the BeerXML spec, this behavior is implicitly falsey.
+
+   Therefore, if the :add-after-boil field is not present, this function will explicitly return false."
+  {:added "1.5"}
+  [fermentable]
+  (if (contains? fermentable :add-after-boil)
+    (:add-after-boil fermentable)
+    false))
+
+
+(defn grain?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) is whole grain.
+   This function will throw an exception if the `type` field is not present.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["sugar?"
+              "extract?"
+              "dry-extract?"
+              "adjunct?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([fermentable] (grain? fermentable {}))
+  ([fermentable opts]
+   (let [fermentable-type (impl/fetch-or-throw! fermentable :type "Fermentable :type is required to determine if it is a grain.")]
+     (spoon.string/same-text? "grain" fermentable-type opts))))
+
+
+(defn sugar?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) is a raw sugar.
+   This function will throw an exception if the `type` field is not present.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["grain?"
+              "extract?"
+              "dry-extract?"
+              "adjunct?"
+              "spoon.string/same-text?"]}
+  ([fermentable] (sugar? fermentable {}))
+  ([fermentable opts]
+   (let [fermentable-type (impl/fetch-or-throw! fermentable :type "Fermentable :type is required to determine if it is a sugar")]
+     (spoon.string/same-text? "sugar" fermentable-type opts))))
+
+
+(defn extract?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) is a liquid malt extract.
+   This function will throw an exception if the `type` field is not present.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["grain?"
+              "sugar?"
+              "dry-extract?"
+              "adjunct?"
+              "spoon.string/same-text?"]}
+  ([fermentable] (extract? fermentable {}))
+  ([fermentable opts]
+   (let [fermentable-type (impl/fetch-or-throw! fermentable :type "Fermentable :type is required to determine if it is a extract.")]
+     (spoon.string/same-text? "extract" fermentable-type opts))))
+
+
+(defn dry-extract?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) is dried malt extract.
+   This function will throw an exception if the `type` field is not present.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["grain?"
+              "sugar?"
+              "extract?"
+              "adjunct?"
+              "spoon.string/same-text?"]}
+  ([fermentable] (dry-extract? fermentable {}))
+  ([fermentable opts]
+   (let [fermentable-type (impl/fetch-or-throw! fermentable :type "Fermentable :type is required to determine if it is a dry extract.")]
+     (spoon.string/same-text? "dry extract" fermentable-type opts))))
+
+
+(defn adjunct?
+  "A predicate function to determine if a [fermentable](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/fermentables.cljc) is an adjunct, non-standard fermentable.
+   This function will throw an exception if the `type` field is not present.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["grain?"
+              "sugar?"
+              "extract?"
+              "dry-extract?"
+              "spoon.string/same-text?"]}
+  ([fermentable] (adjunct? fermentable {}))
+  ([fermentable opts]
+   (let [fermentable-type (impl/fetch-or-throw! fermentable :type "Fermentable :type is required to determine if it is an adjunct.")]
+     (spoon.string/same-text? "adjunct" fermentable-type opts))))

--- a/src/brewtility/predicates/hops.cljc
+++ b/src/brewtility/predicates/hops.cljc
@@ -1,0 +1,213 @@
+(ns brewtility.predicates.hops
+  "Predicate functions for [hops](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) maps."
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+;;
+;; :use functions
+;;
+
+
+(defn boil?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was used during the boil.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["dry-hop?"
+              "mash?"
+              "first-wort?"
+              "aroma?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (boil? hop {}))
+  ([hop opts]
+   (let [hop-use (impl/fetch-or-throw! hop :use "Hop :use is required to determine if it is added during the boil.")]
+     (spoon.string/same-text? "boil" hop-use opts))))
+
+
+(defn dry-hop?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was used as a dry-hop addition in secondary fermentation.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "mash?"
+              "first-wort?"
+              "aroma?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (dry-hop? hop {}))
+  ([hop opts]
+   (let [hop-use (impl/fetch-or-throw! hop :use "Hop :use is required to determine if it is added as a dry hop.")]
+     (spoon.string/same-text? "dry hop" hop-use opts))))
+
+
+(defn mash?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added during the mash and before the boil.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "dry-hop?"
+              "first-wort?"
+              "aroma?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (mash? hop {}))
+  ([hop opts]
+   (let [hop-use (impl/fetch-or-throw! hop :use "Hop :use is required to determine if it is added in the mash.")]
+     (spoon.string/same-text? "mash" hop-use opts))))
+
+
+(defn first-wort?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added to the wort at the first possible moment.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "dry-hop?"
+              "mash?"
+              "aroma?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (first-wort? hop {}))
+  ([hop opts]
+   (let [hop-use (impl/fetch-or-throw! hop :use "Hop :use is required to determine if it is added to the wort")]
+     (spoon.string/same-text? "first wort" hop-use opts))))
+
+
+(defn aroma-use?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added at the end of the boil for aroma.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "dry-hop?"
+              "mash?"
+              "first-wort?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (aroma-use? hop {}))
+  ([hop opts]
+   (let [hop-use (impl/fetch-or-throw! hop :use "Hop :use is required to determine if it is added at the end of the boil.")]
+     (spoon.string/same-text? "aroma" hop-use opts))))
+
+
+;;
+;; :type functions
+;;
+
+(defn aroma-type?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added for aroma.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["bittering?"
+              "both?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (aroma-type? hop {}))
+  ([hop opts]
+   (let [hop-type (impl/fetch-or-throw! hop :type "Hop :type is required to determine if it is added for aroma.")]
+     (spoon.string/same-text? "aroma" hop-type opts))))
+
+
+(defn bittering?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added for bittering.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["aroma-type?"
+              "both?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (bittering? hop {}))
+  ([hop opts]
+   (let [hop-type (impl/fetch-or-throw! hop :type "Hop :type is required to determine if it is added for bitterness.")]
+     (spoon.string/same-text? "bittering" hop-type opts))))
+
+
+(defn both?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was added for both bittering and aroma.
+   An option map can be passed to this function as an optional second parameter.
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false.
+     - `:coerce` - If the `:type` field should be coerced to a string for comparison. Default is false."
+  {:added    "1.5"
+   :see-also ["aroma-type?"
+              "bittering?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (both? hop {}))
+  ([hop opts]
+   (let [hop-type (impl/fetch-or-throw! hop :type "Hop :type is required to determine if it is added for both bitterness and aroma.")]
+     (spoon.string/same-text? "both" hop-type opts))))
+
+
+;;
+;; :form functions
+;;
+
+
+(defn pellet?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was a compressed pellet.
+   An option map can be passed to this function as an optional second parameter.
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:form` should be cast to UPPERCASE instead of lowercase. Default is false.
+     - `:coerce` - If the `:form` field should be coerced to a string for comparison. Default is false."
+  {:added    "1.5"
+   :see-also ["plug?"
+              "leaf?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (pellet? hop {}))
+  ([hop opts]
+   (let [hop-form (impl/fetch-or-throw! hop :form "Hop :form is required to determine if it is a compressed pellet.")]
+     (spoon.string/same-text? "pellet" hop-form opts))))
+
+
+(defn plug?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was a compressed whole-hop plug.
+   An option map can be passed to this function as an optional second parameter.
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:form` should be cast to UPPERCASE instead of lowercase. Default is false.
+     - `:coerce` - If the `:form` field should be coerced to a string for comparison. Default is false."
+  {:added    "1.5"
+   :see-also ["pellet?"
+              "leaf?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (plug? hop {}))
+  ([hop opts]
+   (let [hop-form (impl/fetch-or-throw! hop :form "Hop :form is required to determine if it is a compressed whole hop.")]
+     (spoon.string/same-text? "plug" hop-form opts))))
+
+
+(defn leaf?
+  "A predicate function to determine if a [hop](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/hops.cljc) was a whole hop cone.
+   An option map can be passed to this function as an optional second parameter.
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:form` should be cast to UPPERCASE instead of lowercase. Default is false.
+     - `:coerce` - If the `:form` field should be coerced to a string for comparison. Default is false."
+  {:added    "1.5"
+   :see-also ["pellet?"
+              "plug?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([hop] (leaf? hop {}))
+  ([hop opts]
+   (let [hop-form (impl/fetch-or-throw! hop :form "Hop :form is required to determine if it is a whole hop cone.")]
+     (spoon.string/same-text? "leaf" hop-form opts))))

--- a/src/brewtility/predicates/impl.cljc
+++ b/src/brewtility/predicates/impl.cljc
@@ -1,0 +1,24 @@
+(ns brewtility.predicates.impl
+  "Function to help minimize repeated code in predicate functions.
+
+   Not intended for public consumption."
+  {:added               "1.5"
+   :no-doc              true
+   :implementation-only true})
+
+
+(defn fetch-or-throw!
+  "A helper function to fetch a value from a map or throw an exception.
+   Many predicates require information that is not automatically inferable, and no sane default may be assumed.
+   Exception metadata is added to indicate the missing key and the map that was searched.
+
+   Not intended for public consumption."
+  {:added  "1.5"
+   :no-doc true}
+  [map' key' message]
+  (let [value (get map' key' ::not-found)]
+    (if (and (some? value) (not= value ::not-found))
+      value
+      (throw (ex-info message {:error-type     :missing-key
+                               :missing-key    key'
+                               :original-value map'})))))

--- a/src/brewtility/predicates/mash.cljc
+++ b/src/brewtility/predicates/mash.cljc
@@ -1,0 +1,72 @@
+(ns brewtility.predicates.mash
+  "Predicate functions for [mash](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/mash.cljc) maps."
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+(defn adjust-for-equipment?
+  "A predicate function to determine if a [mash](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/mash.cljc) should account for any temperature effects of the equipment used.
+   In the BeerXML spec, this behavior is implicitly falsey.
+   Therefore, if the `:equip-adjust` field is not present, this function will return false."
+  {:added "1.5"}
+  [mash]
+  (if (contains? mash :equip-adjust)
+    (:equip-adjust mash)
+    false))
+
+
+(defn infusion?
+  "A predicate function to determine if a [mash-step](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/mash.cljc) is used as a basic infusion.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["temperature?"
+              "decoction?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([mash-step] (infusion? mash-step {}))
+  ([mash-step opts]
+   (let [mash-step-type (impl/fetch-or-throw! mash-step :type "Mash step :type is required to determine if it's an infusion step.")]
+     (spoon.string/same-text? "infusion" mash-step-type opts))))
+
+
+(defn temperature?
+  "A predicate function to determine if a [mash-step](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/mash.cljc) is used to bring wort up to temperature.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["infusion?"
+              "decoction?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([mash-step] (temperature? mash-step {}))
+  ([mash-step opts]
+   (let [mash-step-type (impl/fetch-or-throw! mash-step :type "Mash step :type is required to determine if it's used to increase wort temperature.")]
+     (spoon.string/same-text? "temperature" mash-step-type opts))))
+
+
+(defn decoction?
+  "A predicate function to determine if a [mash-step](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/mash.cljc) is used to extract and concentrate flavor.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["infusion?"
+              "temperature?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([mash-step] (decoction? mash-step {}))
+  ([mash-step opts]
+   (let [mash-step-type (impl/fetch-or-throw! mash-step :type "Mash step :type is required to determine if it's used to concentrate flavors by evaporating water.")]
+     (spoon.string/same-text? "decoction" mash-step-type opts))))

--- a/src/brewtility/predicates/miscs.cljc
+++ b/src/brewtility/predicates/miscs.cljc
@@ -1,0 +1,217 @@
+(ns brewtility.predicates.miscs
+  "Predicate functions for [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) maps"
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+(defn spice?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is a spice.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["fining?"
+              "water-agent?"
+              "herb?"
+              "flavor?"
+              "other?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (spice? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it's a spice")]
+     (spoon.string/same-text? "spice" misc-type opts))))
+
+
+(defn fining?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is used to remove yeast and protein haze.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["spice?"
+              "water-agent?"
+              "herb?"
+              "flavor?"
+              "other?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (fining? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it's used for fining")]
+     (spoon.string/same-text? "fining" misc-type opts))))
+
+
+(defn water-agent?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is a water agent.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["spice?"
+              "other?"
+              "fining?"
+              "herb?"
+              "flavor?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (water-agent? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it a water agent")]
+     (spoon.string/same-text? "water agent" misc-type opts))))
+
+
+(defn herb?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is a herb.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["spice?"
+              "water-agent?"
+              "fining?"
+              "flavor?"
+              "other?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (herb? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it an herb")]
+     (spoon.string/same-text? "herb" misc-type opts))))
+
+
+(defn flavor?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is added for flavor.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["spice?"
+              "water-agent?"
+              "fining?"
+              "herb?"
+              "other?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (flavor? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it was added for flavor")]
+     (spoon.string/same-text? "flavor" misc-type opts))))
+
+
+(defn other?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) is an unspecified type.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["spice?"
+              "water-agent?"
+              "fining?"
+              "herb?"
+              "flavor?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (other? misc {}))
+  ([misc opts]
+   (let [misc-type (impl/fetch-or-throw! misc :type "Misc :type is required to determine if it doesn't fit any other category")]
+     (spoon.string/same-text? "other" misc-type opts))))
+
+
+(defn boil?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) was added during the boil.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["mash?"
+              "primary?"
+              "secondary?"
+              "bottling?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (boil? misc {}))
+  ([misc opts]
+   (let [misc-use (impl/fetch-or-throw! misc :use "Misc :use is required to determine if it was added during the boil")]
+     (spoon.string/same-text? "boil" misc-use opts))))
+
+
+(defn mash?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) was added during the mash.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "primary?"
+              "secondary?"
+              "bottling?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (mash? misc {}))
+  ([misc opts]
+   (let [misc-use (impl/fetch-or-throw! misc :use "Misc :use is required to determine if it was added during the mash")]
+     (spoon.string/same-text? "mash" misc-use opts))))
+
+
+(defn primary?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) was added during the primary fermentation.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "mash?"
+              "secondary?"
+              "bottling?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (primary? misc {}))
+  ([misc opts]
+   (let [misc-use (impl/fetch-or-throw! misc :use "Misc :use is required to determine if it was added during primary fermentation")]
+     (spoon.string/same-text? "primary" misc-use opts))))
+
+
+(defn secondary?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) was added during the secondary fermentation.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "mash?"
+              "primary?"
+              "bottling?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (secondary? misc {}))
+  ([misc opts]
+   (let [misc-use (impl/fetch-or-throw! misc :use "Misc :use is required to determine if it was added during secondary fermentation")]
+     (spoon.string/same-text? "secondary" misc-use opts))))
+
+
+(defn bottling?
+  "A predicate function to determine if a [misc](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/miscs.cljc) was added during bottle conditioning.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:use` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["boil?"
+              "mash?"
+              "primary?"
+              "secondary?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([misc] (bottling? misc {}))
+  ([misc opts]
+   (let [misc-use (impl/fetch-or-throw! misc :use "Misc :use is required to determine if it was added during bottle conditioning")]
+     (spoon.string/same-text? "bottling" misc-use opts))))

--- a/src/brewtility/predicates/recipes.cljc
+++ b/src/brewtility/predicates/recipes.cljc
@@ -1,0 +1,125 @@
+(ns brewtility.predicates.recipes
+  "Predicate functions for [recipe](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) maps"
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+(defn forced-carbonation?
+  "A predicate function to determine if a [recipe](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) was forcefully carbonated.
+   In the BeerXML spec, this behavior is implicitly falsey.
+   Therefore, if the :forced-carbonation field is not present, this function will explicitly return false."
+  {:added "1.5"}
+  [recipe]
+  (if (contains? recipe :forced-carbonation)
+    (:forced-carbonation recipe)
+    false))
+
+
+(defn extract?
+  "A predicate function to determine if a [recipe](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) was made with extract only.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["all-grain?"
+              "partial-mash?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (extract? recipe {}))
+  ([recipe opts]
+   (let [recipe-type (impl/fetch-or-throw! recipe :type "Recipe :type is required to determine if it's based on malt extract")]
+     (spoon.string/same-text? "extract" recipe-type opts))))
+
+
+(defn partial-mash?
+  "A predicate function to determine if a [recipe](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) was partially mashed.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["extract?"
+              "all-grain?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (partial-mash? recipe {}))
+  ([recipe opts]
+   (let [recipe-type (impl/fetch-or-throw! recipe :type "Recipe :type is required to determine if it was partially mashed")]
+     (spoon.string/same-text? "partial mash" recipe-type opts))))
+
+
+(defn all-grain?
+  "A predicate function to determine if a [recipe](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) was made entirely of grain.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["extract?"
+              "partial-mash?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (all-grain? recipe {}))
+  ([recipe opts]
+   (let [recipe-type (impl/fetch-or-throw! recipe :type "Recipe :type is required to determine if it was brewed with grain only")]
+     (spoon.string/same-text? "all grain" recipe-type opts))))
+
+
+(defn rager?
+  "A predicate function to determine if a [recipe's](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) IBU was calculated with the Rager method.
+   This method was originally developed by Jackie Rager, and is most accurate for partial mash recipes.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:ibu-method` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["tinseth?"
+              "garetz?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (rager? recipe {}))
+  ([recipe opts]
+   (let [recipe-ibu-method (impl/fetch-or-throw! recipe :ibu-method "Recipe :ibu-method is required to determine if IBUs were calculated with the Rager method")]
+     (spoon.string/same-text? "rager" recipe-ibu-method opts))))
+
+
+(defn tinseth?
+  "A predicate function to determine if a [recipe's](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) IBU was calculated with the tinseth method.
+   This method was originally developed by Glenn Tinseth, and is most accurate for all grain recipes.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:ibu-method` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["rager?"
+              "garetz?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (tinseth? recipe {}))
+  ([recipe opts]
+   (let [recipe-ibu-method (impl/fetch-or-throw! recipe :ibu-method "Recipe :ibu-method is required to determine if IBUs were calculated with the Tinseth method")]
+     (spoon.string/same-text? "tinseth" recipe-ibu-method opts))))
+
+
+(defn garetz?
+  "A predicate function to determine if a [recipe's](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/recipes.cljc) IBU was calculated with the garetz method.
+   This method was originally developed by Mark Garetz, and is most accurate for High IBU recipes.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:ibu-method` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["rager?"
+              "tinseth?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([recipe] (garetz? recipe {}))
+  ([recipe opts]
+   (let [recipe-ibu-method (impl/fetch-or-throw! recipe :ibu-method "Recipe :ibu-method is required to determine if IBUs were calculated with the Garetz method")]
+     (spoon.string/same-text? "garetz" recipe-ibu-method opts))))
+
+

--- a/src/brewtility/predicates/styles.cljc
+++ b/src/brewtility/predicates/styles.cljc
@@ -1,0 +1,127 @@
+(ns brewtility.predicates.styles
+  "Predicate functions for [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) maps"
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+(defn lager?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for lagers.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["ale?"
+              "mead?"
+              "wheat?"
+              "mixed?"
+              "cider?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (lager? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for lagers")]
+     (spoon.string/same-text? "lager" style-type opts))))
+
+
+(defn ale?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for ales.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "mead?"
+              "wheat?"
+              "mixed?"
+              "cider?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (ale? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for ales")]
+     (spoon.string/same-text? "ale" style-type opts))))
+
+
+(defn mead?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for meads.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "ale?"
+              "wheat?"
+              "mixed?"
+              "cider?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (mead? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for meads")]
+     (spoon.string/same-text? "mead" style-type opts))))
+
+
+(defn wheat?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for wheat beers.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "ale?"
+              "mead?"
+              "mixed?"
+              "cider?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (wheat? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for wheat beers")]
+     (spoon.string/same-text? "wheat" style-type opts))))
+
+
+(defn mixed?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for blended/mixed beers.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "ale?"
+              "mead?"
+              "wheat?"
+              "cider?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (mixed? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for mixed styles or blends")]
+     (spoon.string/same-text? "mixed" style-type opts))))
+
+
+(defn cider?
+  "A predicate function to determine if a [style](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/styles.cljc) is for ciders.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "ale?"
+              "mead?"
+              "wheat?"
+              "mixed?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([style] (cider? style {}))
+  ([style opts]
+   (let [style-type (impl/fetch-or-throw! style :type "Style :type is required to determine if it's for ciders")]
+     (spoon.string/same-text? "cider" style-type opts))))

--- a/src/brewtility/predicates/waters.cljc
+++ b/src/brewtility/predicates/waters.cljc
@@ -1,0 +1,42 @@
+(ns brewtility.predicates.waters
+  "Predicate functions for [water](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/waters.cljc) maps."
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]))
+
+
+(defn acidic?
+  "A predicate function to determine if a [water](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/waters.cljc) profile is acidic."
+  {:added    "1.5"
+   :see-also ["alkaline?"
+              "neutral?"]}
+  [water]
+  (let [ph (impl/fetch-or-throw! water :ph "Water `:ph` is required to determine acidity.")]
+    (> 7 ph)))
+
+
+(defn alkaline?
+  "A predicate function to determine if a [water](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/waters.cljc) profile is alkaline."
+  {:added    "1.5"
+   :see-also ["acidic?"
+              "neutral?"]}
+  [water]
+  (let [ph (impl/fetch-or-throw! water :ph "Water `:ph` is required to determine alkalinity.")]
+    (< 7 ph)))
+
+
+(defn neutral?
+  "A predicate function to determine if a [water](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/waters.cljc) profile is alkaline."
+  {:added    "1.5"
+   :see-also ["acidic?"
+              "alkaline?"]}
+  [water]
+  (let [ph (impl/fetch-or-throw! water :ph "Water `:ph` is required to determine ph neutrality.")]
+    (== 7 ph)))

--- a/src/brewtility/predicates/yeasts.cljc
+++ b/src/brewtility/predicates/yeasts.cljc
@@ -1,0 +1,253 @@
+(ns brewtility.predicates.yeasts
+  "Predicate functions for [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) maps"
+  {:added    "1.5"
+   :see-also ["brewtility.predicates.equipment"
+              "brewtility.predicates.fermentables"
+              "brewtility.predicates.hops"
+              "brewtility.predicates.mash"
+              "brewtility.predicates.miscs"
+              "brewtility.predicates.recipes"
+              "brewtility.predicates.styles"
+              "brewtility.predicates.waters"
+              "brewtility.predicates.yeasts"]}
+  (:require [brewtility.predicates.impl :as impl]
+            [com.wallbrew.spoon.string :as spoon.string]))
+
+
+;;
+;; :type functions
+;;
+
+(defn ale?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is for ale.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["lager?"
+              "wheat?"
+              "wine?"
+              "champagne?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (ale? yeast {}))
+  ([yeast opts]
+   (let [yeast-type (impl/fetch-or-throw! yeast :type "Yeast :type is required to determine if it's for ales")]
+     (spoon.string/same-text? "ale" yeast-type opts))))
+
+
+(defn lager?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is for lager.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["ale?"
+              "wheat?"
+              "wine?"
+              "champagne?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (lager? yeast {}))
+  ([yeast opts]
+   (let [yeast-type (impl/fetch-or-throw! yeast :type "Yeast :type is required to determine if it's for lagers")]
+     (spoon.string/same-text? "lager" yeast-type opts))))
+
+
+(defn wheat?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is for wheat beers.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["ale?"
+              "lager?"
+              "wine?"
+              "champagne?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (wheat? yeast {}))
+  ([yeast opts]
+   (let [yeast-type (impl/fetch-or-throw! yeast :type "Yeast :type is required to determine if it's for wheat beers")]
+     (spoon.string/same-text? "wheat" yeast-type opts))))
+
+
+(defn wine?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is a common wine strain.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["ale?"
+              "lager?"
+              "wheat?"
+              "champagne?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (wine? yeast {}))
+  ([yeast opts]
+   (let [yeast-type (impl/fetch-or-throw! yeast :type "Yeast :type is required to determine if it's a strain typical to wines")]
+     (spoon.string/same-text? "wine" yeast-type opts))))
+
+
+(defn champagne?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is a common champagne strain.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["ale?"
+              "lager?"
+              "wheat?"
+              "wine?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (champagne? yeast {}))
+  ([yeast opts]
+   (let [yeast-type (impl/fetch-or-throw! yeast :type "Yeast :type is required to determine if it's a strain typical to champagnes")]
+     (spoon.string/same-text? "champagne" yeast-type opts))))
+
+
+;;
+;; :form functions
+;;
+
+(defn liquid?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is in liquid form.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["dry?"
+              "slant?"
+              "culture?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (liquid? yeast {}))
+  ([yeast opts]
+   (let [yeast-form (impl/fetch-or-throw! yeast :form "Yeast :form is required to determine if it is in liquid form")]
+     (spoon.string/same-text? "liquid" yeast-form opts))))
+
+
+(defn dry?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is in dry form.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["liquid?"
+              "slant?"
+              "culture?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (dry? yeast {}))
+  ([yeast opts]
+   (let [yeast-form (impl/fetch-or-throw! yeast :form "Yeast :form is required to determine if it is in dry form")]
+     (spoon.string/same-text? "dry" yeast-form opts))))
+
+
+(defn slant?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is in slant form.
+   Typically, this is a solid growth of yeast cells in a test tube.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["liquid?"
+              "dry?"
+              "culture?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (slant? yeast {}))
+  ([yeast opts]
+   (let [yeast-form (impl/fetch-or-throw! yeast :form "Yeast :form is required to determine if it is in slant form")]
+     (spoon.string/same-text? "slant" yeast-form opts))))
+
+
+(defn culture?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) is a living culture.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["liquid?"
+              "dry?"
+              "slant?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (culture? yeast {}))
+  ([yeast opts]
+   (let [yeast-form (impl/fetch-or-throw! yeast :form "Yeast :form is required to determine if it is in culture form")]
+     (spoon.string/same-text? "culture" yeast-form opts))))
+
+
+;;
+;; :flocculation functions
+;;
+
+(defn low-flocculation?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) generates a low amount of floc.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["medium-flocculation?"
+              "high-flocculation?"
+              "very-high-flocculation?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (low-flocculation? yeast {}))
+  ([yeast opts]
+   (let [yeast-flocculation (impl/fetch-or-throw! yeast :flocculation "Yeast :flocculation is required to determine if generates a low amount of floc")]
+     (spoon.string/same-text? "low" yeast-flocculation opts))))
+
+
+(defn medium-flocculation?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) generates a medium amount of floc.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["low-flocculation?"
+              "high-flocculation?"
+              "very-high-flocculation?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (medium-flocculation? yeast {}))
+  ([yeast opts]
+   (let [yeast-flocculation (impl/fetch-or-throw! yeast :flocculation "Yeast :flocculation is required to determine if generates a medium amount of floc")]
+     (spoon.string/same-text? "medium" yeast-flocculation opts))))
+
+
+(defn high-flocculation?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) generates a high amount of floc.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["low-flocculation?"
+              "high-flocculation?"
+              "very-high-flocculation?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (high-flocculation? yeast {}))
+  ([yeast opts]
+   (let [yeast-flocculation (impl/fetch-or-throw! yeast :flocculation "Yeast :flocculation is required to determine if generates a high amount of floc")]
+     (spoon.string/same-text? "high" yeast-flocculation opts))))
+
+
+(defn very-high-flocculation?
+  "A predicate function to determine if a [yeast](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/src/common_beer_format/yeasts.cljc) generates a very high amount of floc.
+   An option map can be passed to this function as an optional second parameter.
+
+   Supported keys are:
+     - `:uppercase?` - If the string comparison for the `:type` should be cast to UPPERCASE instead of lowercase. Default is false."
+  {:added    "1.5"
+   :see-also ["low-flocculation?"
+              "high-flocculation?"
+              "medium-flocculation?"
+              "com.wallbrew.spoon.string/same-text?"]}
+  ([yeast] (very-high-flocculation? yeast {}))
+  ([yeast opts]
+   (let [yeast-flocculation (impl/fetch-or-throw! yeast :flocculation "Yeast :flocculation is required to determine if generates a very high amount of floc")]
+     (spoon.string/same-text? "very high" yeast-flocculation opts))))

--- a/src/brewtility/wrapping.cljc
+++ b/src/brewtility/wrapping.cljc
@@ -1,6 +1,6 @@
 (ns brewtility.wrapping
   "Namespace for wrapping and unwrapping common-beer-format maps.
-   
+
    Since the BeerXML format wraps attributes in tags indicating the type of ingreditent/process/etc.,
      the analogous common-beer-format maps are nested in a map with a single key.
    This namespace provides functions for wrapping and unwrapping these maps."

--- a/test/brewtility/calculations_test.cljc
+++ b/test/brewtility/calculations_test.cljc
@@ -107,3 +107,33 @@
       (is (= 68.93  (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 15 1.03))))
       (is (= 34.465  (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 30 1.03))))
       (is (= 52.64 (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 15 1.06)))))))
+
+(deftest calculate-equipment-boil-volume-test
+  (testing "An exception is thrown when data required for the calculation is missing"
+    #?(:clj (is (thrown-with-msg? Exception #"Cannot calculate boil volume with non-numeric values" (sut/calculate-equipment-boil-volume {}))))
+    #?(:cljs (is (thrown-with-msg? js/Error #"Cannot calculate boil volume with non-numeric values" (sut/calculate-equipment-boil-volume {})))))
+  (testing "Verify calculation correctness"
+    (is (= 1.0 (sut/calculate-equipment-boil-volume {:batch-size        1.0
+                                                     :top-up-water      0.0
+                                                     :trub-chiller-loss 0.0
+                                                     :boil-time         0.0
+                                                     :evap-rate         9.0}))
+        "When the boil time is zero, the boil volume is equal to the batch size")
+    (is (= 0.0 (sut/calculate-equipment-boil-volume {:batch-size        1.0
+                                                     :top-up-water      0.5
+                                                     :trub-chiller-loss 0.5
+                                                     :boil-time         0.0
+                                                     :evap-rate         9.0}))
+        "If the batch size is all replacement/lost water, the boil size is 0")
+    (is (= 1.1 (sut/calculate-equipment-boil-volume {:batch-size        1.0
+                                                     :top-up-water      0.0
+                                                     :trub-chiller-loss 0.0
+                                                     :boil-time         60.0
+                                                     :evap-rate         10.0}))
+        "A ten percent loss of water with no replacement water")
+    (is (= 0.55 (sut/calculate-equipment-boil-volume {:batch-size        1.0
+                                                      :top-up-water      0.5
+                                                      :trub-chiller-loss 0.0
+                                                      :boil-time         60.0
+                                                      :evap-rate         10.0}))
+        "A ten percent loss of water after a half-gallon  addition")))

--- a/test/brewtility/calculations_test.cljc
+++ b/test/brewtility/calculations_test.cljc
@@ -33,7 +33,7 @@
       (is (= 20.784 (bp/->3dp (sut/calculate-malt-color-units fermentables batch-size))))
       (is (= 21.273 (bp/->3dp (sut/calculate-srm-color fermentables batch-size))))
       (is (= 41.907 (bp/->3dp (sut/calculate-ebc-color fermentables batch-size))))
-      (is (= 41.907 (bp/->3dp (sut/calculate-lovibond-color fermentables batch-size))))
+      (is (= 16.265 (bp/->3dp (sut/calculate-lovibond-color fermentables batch-size))))
       (is (= color/srm-21 (sut/calculate-rgba-color fermentables batch-size))))))
 
 
@@ -107,6 +107,7 @@
       (is (= 68.93  (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 15 1.03))))
       (is (= 34.465  (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 30 1.03))))
       (is (= 52.64 (bp/->3dp (sut/calculate-recipe-ibus [(assoc hop-1 :amount 0.01 :time 120) (assoc hop-2 :amount 0.02 :time 60)] 15 1.06)))))))
+
 
 (deftest calculate-equipment-boil-volume-test
   (testing "An exception is thrown when data required for the calculation is missing"

--- a/test/brewtility/color_test.cljc
+++ b/test/brewtility/color_test.cljc
@@ -1,8 +1,8 @@
 (ns brewtility.color-test
-  (:require [brewtility.color :as sut]
-            [brewtility.precision :as bp]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.color :as sut]
+            [brewtility.precision :as bp]))
 
 
 (deftest srm->rgba-test

--- a/test/brewtility/precision_test.cljc
+++ b/test/brewtility/precision_test.cljc
@@ -1,7 +1,7 @@
 (ns brewtility.precision-test
-  (:require [brewtility.precision :as sut]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.precision :as sut]))
 
 
 (deftest approximates?-test

--- a/test/brewtility/predicates/equipment_test.cljc
+++ b/test/brewtility/predicates/equipment_test.cljc
@@ -1,0 +1,19 @@
+(ns brewtility.predicates.equipment-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.equipment :as equipment]
+            [brewtility.predicates.equipment :as sut]
+            [common-beer-format.equipment :as cbf-equipment]))
+
+
+(deftest calculated-boil-volume?-tests
+  (testing "When the `:calc-boil-volume` field is present, use that value."
+    (is (true? (sut/calculated-boil-volume? (assoc equipment/sample-equipment :calc-boil-volume true))))
+    (is (false? (sut/calculated-boil-volume? (assoc equipment/sample-equipment :calc-boil-volume false))))
+    (is (true? (sut/calculated-boil-volume? (assoc equipment/sample-equipment cbf-equipment/calc-boil-volume true))))
+    (is (false? (sut/calculated-boil-volume? (assoc equipment/sample-equipment cbf-equipment/calc-boil-volume false)))))
+  (testing "When the `:calc-boil-volume` field is missing, return false."
+    (is (false? (sut/calculated-boil-volume? (dissoc equipment/sample-equipment cbf-equipment/calc-boil-volume)))))
+  (testing "This is a function from a equipment to a boolean."
+    (is (boolean? (sut/calculated-boil-volume? equipment/sample-equipment)))
+    (is (boolean? (sut/calculated-boil-volume? (equipment/generate-equipment))))))

--- a/test/brewtility/predicates/fermentables_test.cljc
+++ b/test/brewtility/predicates/fermentables_test.cljc
@@ -1,0 +1,143 @@
+(ns brewtility.predicates.fermentables-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.fermentables :as fermentables]
+            [brewtility.predicates.fermentables :as sut]
+            [common-beer-format.fermentables :as cbf-fermentables]))
+
+
+(deftest add-after-boil?-tests
+  (testing "When the `:add-after-boil` field is present, use that value."
+    (is (true? (sut/add-after-boil? (assoc fermentables/sample-fermentable :add-after-boil true))))
+    (is (false? (sut/add-after-boil? (assoc fermentables/sample-fermentable :add-after-boil false)))))
+  (testing "When the `:add-after-boil` field is missing, return false."
+    (is (false? (sut/add-after-boil? (dissoc fermentables/sample-fermentable :add-after-boil)))))
+  (testing "This is a function from a fermentable to a boolean."
+    (is (boolean? (sut/add-after-boil? fermentables/sample-fermentable)))
+    (is (boolean? (sut/add-after-boil? (fermentables/generate-fermentable))))))
+
+
+(deftest grain?-test
+  (testing "A fermentable with a `:type` matching `\"grain\" returns true"
+    (is (true? (sut/grain? (assoc fermentables/sample-fermentable :type "Grain"))))
+    (is (true? (sut/grain? (assoc fermentables/sample-fermentable :type cbf-fermentables/grain)))))
+  (testing "A fermentable with a `:type` not matching `\"grain\" returns false"
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type "extract"))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type cbf-fermentables/extract))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type "sUgar"))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type cbf-fermentables/sugar))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type "Dry EXTract"))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type cbf-fermentables/dry-extract))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type "adJunct"))))
+    (is (false? (sut/grain? (assoc fermentables/sample-fermentable :type cbf-fermentables/adjunct)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/grain? fermentables/sample-fermentable)))
+    (is (boolean? (sut/grain? (fermentables/generate-fermentable)))))
+  (testing "If the fermentable is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Fermentable :type"
+                  (sut/grain? (dissoc fermentables/sample-fermentable :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Fermentable :type"
+                   (sut/grain? (dissoc fermentables/sample-fermentable :type)))))))
+
+
+(deftest sugar?-test
+  (testing "A fermentable with a `:type` matching `\"grain\" returns true"
+    (is (true? (sut/sugar? (assoc fermentables/sample-fermentable :type "sugar"))))
+    (is (true? (sut/sugar? (assoc fermentables/sample-fermentable :type "SUGAR"))))
+    (is (true? (sut/sugar? (assoc fermentables/sample-fermentable :type cbf-fermentables/sugar)))))
+  (testing "A fermentable with a `:type` not matching `\"grain\" returns false"
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type "extract"))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type "GRAIN"))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type "Dry EXTract"))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type "adJunct"))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type cbf-fermentables/extract))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type cbf-fermentables/grain))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type cbf-fermentables/dry-extract))))
+    (is (false? (sut/sugar? (assoc fermentables/sample-fermentable :type cbf-fermentables/adjunct)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/sugar? fermentables/sample-fermentable)))
+    (is (boolean? (sut/sugar? (fermentables/generate-fermentable)))))
+  (testing "If the fermentable is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Fermentable :type"
+                  (sut/sugar? (dissoc fermentables/sample-fermentable :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Fermentable :type"
+                   (sut/sugar? (dissoc fermentables/sample-fermentable :type)))))))
+
+
+(deftest extract?-test
+  (testing "A fermentable with a `:type` matching `\"grain\" returns true"
+    (is (true? (sut/extract? (assoc fermentables/sample-fermentable :type "EXTRACT"))))
+    (is (true? (sut/extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/extract)))))
+  (testing "A fermentable with a `:type` not matching `\"grain\" returns false"
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type "sugar"))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type "GRAIN"))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type "Dry EXTract"))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type "adJunct"))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/sugar))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/grain))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/dry-extract))))
+    (is (false? (sut/extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/adjunct)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/extract? fermentables/sample-fermentable)))
+    (is (boolean? (sut/extract? (fermentables/generate-fermentable)))))
+  (testing "If the fermentable is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Fermentable :type"
+                  (sut/extract? (dissoc fermentables/sample-fermentable :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Fermentable :type"
+                   (sut/extract? (dissoc fermentables/sample-fermentable :type)))))))
+
+
+(deftest dry-extract?-test
+  (testing "A fermentable with a `:type` matching `\"grain\" returns true"
+    (is (true? (sut/dry-extract? (assoc fermentables/sample-fermentable :type "DRY EXTRACT"))))
+    (is (true? (sut/dry-extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/dry-extract)))))
+  (testing "A fermentable with a `:type` not matching `\"grain\" returns false"
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type "sugar"))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type "GRAIN"))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type "EXTract"))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type "adJunct"))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/sugar))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/grain))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/extract))))
+    (is (false? (sut/dry-extract? (assoc fermentables/sample-fermentable :type cbf-fermentables/adjunct)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/dry-extract? fermentables/sample-fermentable)))
+    (is (boolean? (sut/dry-extract? (fermentables/generate-fermentable)))))
+  (testing "If the fermentable is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Fermentable :type"
+                  (sut/dry-extract? (dissoc fermentables/sample-fermentable :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Fermentable :type"
+                   (sut/dry-extract? (dissoc fermentables/sample-fermentable :type)))))))
+
+
+(deftest adjunct?-test
+  (testing "A fermentable with a `:type` matching `\"grain\" returns true"
+    (is (true? (sut/adjunct? (assoc fermentables/sample-fermentable :type "adJunct"))))
+    (is (true? (sut/adjunct? (assoc fermentables/sample-fermentable :type cbf-fermentables/adjunct)))))
+  (testing "A fermentable with a `:type` not matching `\"grain\" returns false"
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type "sugar"))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type "GRAIN"))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type "EXTract"))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type "DRY EXTRact"))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type cbf-fermentables/sugar))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type cbf-fermentables/grain))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type cbf-fermentables/extract))))
+    (is (false? (sut/adjunct? (assoc fermentables/sample-fermentable :type cbf-fermentables/dry-extract)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/adjunct? fermentables/sample-fermentable)))
+    (is (boolean? (sut/adjunct? (fermentables/generate-fermentable)))))
+  (testing "If the fermentable is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Fermentable :type"
+                  (sut/adjunct? (dissoc fermentables/sample-fermentable :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Fermentable :type"
+                   (sut/adjunct? (dissoc fermentables/sample-fermentable :type)))))))

--- a/test/brewtility/predicates/hops_test.cljc
+++ b/test/brewtility/predicates/hops_test.cljc
@@ -1,0 +1,270 @@
+(ns brewtility.predicates.hops-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.hops :as hops]
+            [brewtility.predicates.hops :as sut]
+            [common-beer-format.hops :as cbf-hops]))
+
+
+;;
+;; :use function tests
+;;
+
+(deftest boil?-test
+  (testing "A hop with a `:use` matching `\"boil\"` returns true"
+    (is (true? (sut/boil? (assoc hops/sample-hop :use "Boil"))))
+    (is (true? (sut/boil? (assoc hops/sample-hop cbf-hops/use cbf-hops/boil)))))
+  (testing "A hop with a `:use` not matching `\"boil\"` returns false"
+    (is (false? (sut/boil? (assoc hops/sample-hop :use "DRY Hop"))))
+    (is (false? (sut/boil? (assoc hops/sample-hop :use "Mash"))))
+    (is (false? (sut/boil? (assoc hops/sample-hop :use "aroma"))))
+    (is (false? (sut/boil? (assoc hops/sample-hop :use "first Wort"))))
+    (is (false? (sut/boil? (assoc hops/sample-hop cbf-hops/use cbf-hops/dry-hop))))
+    (is (false? (sut/boil? (assoc hops/sample-hop cbf-hops/use cbf-hops/mash))))
+    (is (false? (sut/boil? (assoc hops/sample-hop cbf-hops/use cbf-hops/aroma))))
+    (is (false? (sut/boil? (assoc hops/sample-hop cbf-hops/use cbf-hops/first-wort)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/boil? hops/sample-hop)))
+    (is (boolean? (sut/boil? (hops/generate-hop)))))
+  (testing "If the hop is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :use"
+                  (sut/boil? (dissoc hops/sample-hop :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :use"
+                   (sut/boil? (dissoc hops/sample-hop :use)))))))
+
+
+(deftest dry-hop?-test
+  (testing "A hop with a `:use` matching `\"dry hop\"` returns true"
+    (is (true? (sut/dry-hop? (assoc hops/sample-hop :use "Dry Hop"))))
+    (is (true? (sut/dry-hop? (assoc hops/sample-hop :use cbf-hops/dry-hop)))))
+  (testing "A hop with a `:use` not matching `\"dry hop\"` returns false"
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use "boil"))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use "mASh"))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use "aroMA"))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use "first Wort"))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use cbf-hops/boil))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use cbf-hops/mash))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use cbf-hops/aroma))))
+    (is (false? (sut/dry-hop? (assoc hops/sample-hop :use cbf-hops/first-wort)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/dry-hop? hops/sample-hop)))
+    (is (boolean? (sut/dry-hop? (hops/generate-hop)))))
+  (testing "If the hop is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :use"
+                  (sut/dry-hop? (dissoc hops/sample-hop :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :use"
+                   (sut/dry-hop? (dissoc hops/sample-hop :use)))))))
+
+
+(deftest mash?-test
+  (testing "A hop with a `:use` matching `\"mash\"` returns true"
+    (is (true? (sut/mash? (assoc hops/sample-hop :use "mash"))))
+    (is (true? (sut/mash? (assoc hops/sample-hop :use cbf-hops/mash)))))
+  (testing "A hop with a `:use` not matching `\"mash\"` returns false"
+    (is (false? (sut/mash? (assoc hops/sample-hop :use "DRY Hop"))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use "bOIL"))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use "aroma"))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use "first Wort"))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use cbf-hops/dry-hop))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use cbf-hops/boil))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use cbf-hops/aroma))))
+    (is (false? (sut/mash? (assoc hops/sample-hop :use cbf-hops/first-wort)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/mash? hops/sample-hop)))
+    (is (boolean? (sut/mash? (hops/generate-hop)))))
+  (testing "If the hop is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :use"
+                  (sut/mash? (dissoc hops/sample-hop :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :use"
+                   (sut/mash? (dissoc hops/sample-hop :use)))))))
+
+
+(deftest first-wort?-test
+  (testing "A hop with a `:use` matching `\"first wort\"` returns true"
+    (is (true? (sut/first-wort? (assoc hops/sample-hop :use "first wort"))))
+    (is (true? (sut/first-wort? (assoc hops/sample-hop :use cbf-hops/first-wort)))))
+  (testing "A hop with a `:use` not matching `\"first wort\"` returns false"
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use "DRY Hop"))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use "bOIL"))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use "aroma"))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use "mash"))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use cbf-hops/dry-hop))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use cbf-hops/boil))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use cbf-hops/aroma))))
+    (is (false? (sut/first-wort? (assoc hops/sample-hop :use cbf-hops/mash)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/first-wort? hops/sample-hop)))
+    (is (boolean? (sut/first-wort? (hops/generate-hop)))))
+  (testing "If the hop is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :use"
+                  (sut/first-wort? (dissoc hops/sample-hop :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :use"
+                   (sut/first-wort? (dissoc hops/sample-hop :use)))))))
+
+
+(deftest aroma-use?-test
+  (testing "A hop with a `:use` matching `\"aroma\"` returns true"
+    (is (true? (sut/aroma-use? (assoc hops/sample-hop :use "aroma"))))
+    (is (true? (sut/aroma-use? (assoc hops/sample-hop :use cbf-hops/aroma)))))
+  (testing "A hop with a `:use` not matching `\"aroma\"` returns false"
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use "DRY Hop"))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use "bOIL"))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use "mash"))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use "first Wort"))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use cbf-hops/dry-hop))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use cbf-hops/boil))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use cbf-hops/mash))))
+    (is (false? (sut/aroma-use? (assoc hops/sample-hop :use cbf-hops/first-wort)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/aroma-use? hops/sample-hop)))
+    (is (boolean? (sut/aroma-use? (hops/generate-hop)))))
+  (testing "If the hop is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :use"
+                  (sut/aroma-use? (dissoc hops/sample-hop :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :use"
+                   (sut/aroma-use? (dissoc hops/sample-hop :use)))))))
+
+
+;;
+;; :type function tests
+;;
+
+(deftest aroma-type?-test
+  (testing "A hop with a `:type` matching `\"aroma\"` returns true"
+    (is (true? (sut/aroma-type? (assoc hops/sample-hop :type "aroma"))))
+    (is (true? (sut/aroma-type? (assoc hops/sample-hop cbf-hops/type cbf-hops/aroma)))))
+  (testing "A hop with a `:type` not matching `\"aroma\"` returns false"
+    (is (false? (sut/aroma-type? (assoc hops/sample-hop :type "bittering"))))
+    (is (false? (sut/aroma-type? (assoc hops/sample-hop :type "both"))))
+    (is (false? (sut/aroma-type? (assoc hops/sample-hop cbf-hops/type cbf-hops/bittering))))
+    (is (false? (sut/aroma-type? (assoc hops/sample-hop cbf-hops/type cbf-hops/both)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/aroma-type? (assoc hops/sample-hop :type (hops/random-hop-type)))))
+    (is (boolean? (sut/aroma-type? (assoc (hops/generate-hop) :type (hops/random-hop-type))))))
+  (testing "If the hop is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :type"
+                  (sut/aroma-type? (dissoc hops/sample-hop :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :type"
+                   (sut/aroma-type? (dissoc hops/sample-hop :type)))))))
+
+
+(deftest bittering?-test
+  (testing "A hop with a `:type` matching `\"bittering\"` returns true"
+    (is (true? (sut/bittering? (assoc hops/sample-hop :type "bittering"))))
+    (is (true? (sut/bittering? (assoc hops/sample-hop :type cbf-hops/bittering)))))
+  (testing "A hop with a `:type` not matching `\"bittering\"` returns false"
+    (is (false? (sut/bittering? (assoc hops/sample-hop :type "aroma"))))
+    (is (false? (sut/bittering? (assoc hops/sample-hop :type "both"))))
+    (is (false? (sut/bittering? (assoc hops/sample-hop :type cbf-hops/aroma))))
+    (is (false? (sut/bittering? (assoc hops/sample-hop :type cbf-hops/both)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/bittering? (assoc hops/sample-hop :type (hops/random-hop-type)))))
+    (is (boolean? (sut/bittering? (assoc (hops/generate-hop) :type (hops/random-hop-type))))))
+  (testing "If the hop is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :type"
+                  (sut/bittering? (dissoc hops/sample-hop :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :type"
+                   (sut/bittering? (dissoc hops/sample-hop :type)))))))
+
+
+(deftest both?-test
+  (testing "A hop with a `:type` matching `\"both\"` returns true"
+    (is (true? (sut/both? (assoc hops/sample-hop :type "both"))))
+    (is (true? (sut/both? (assoc hops/sample-hop :type cbf-hops/both)))))
+  (testing "A hop with a `:type` not matching `\"both\"` returns false"
+    (is (false? (sut/both? (assoc hops/sample-hop :type "aroma"))))
+    (is (false? (sut/both? (assoc hops/sample-hop :type "bittering"))))
+    (is (false? (sut/both? (assoc hops/sample-hop :type cbf-hops/aroma))))
+    (is (false? (sut/both? (assoc hops/sample-hop :type cbf-hops/bittering)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/both? (assoc hops/sample-hop :type (hops/random-hop-type)))))
+    (is (boolean? (sut/both? (assoc (hops/generate-hop) :type (hops/random-hop-type))))))
+  (testing "If the hop is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :type"
+                  (sut/both? (dissoc hops/sample-hop :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :type"
+                   (sut/both? (dissoc hops/sample-hop :type)))))))
+
+
+;;
+;; :form function tests
+;;
+
+
+(deftest pellet?-test
+  (testing "A hop with a `:form` matching `\"pellet\"` returns true"
+    (is (true? (sut/pellet? (assoc hops/sample-hop :form "pellet"))))
+    (is (true? (sut/pellet? (assoc hops/sample-hop :form cbf-hops/pellet)))))
+  (testing "A hop with a `:form` not matching `\"pellet\"` returns false"
+    (is (false? (sut/pellet? (assoc hops/sample-hop :form "plug"))))
+    (is (false? (sut/pellet? (assoc hops/sample-hop :form "lEAf"))))
+    (is (false? (sut/pellet? (assoc hops/sample-hop :form cbf-hops/plug))))
+    (is (false? (sut/pellet? (assoc hops/sample-hop :form cbf-hops/leaf)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/pellet? (assoc hops/sample-hop :form (hops/random-hop-form)))))
+    (is (boolean? (sut/pellet? (assoc (hops/generate-hop) :form (hops/random-hop-form))))))
+  (testing "If the hop is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :form"
+                  (sut/pellet? (dissoc hops/sample-hop :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :form"
+                   (sut/pellet? (dissoc hops/sample-hop :form)))))))
+
+
+(deftest plug?-test
+  (testing "A hop with a `:form` matching `\"plug\"` returns true"
+    (is (true? (sut/plug? (assoc hops/sample-hop :form "plug"))))
+    (is (true? (sut/plug? (assoc hops/sample-hop cbf-hops/form cbf-hops/plug)))))
+  (testing "A hop with a `:form` not matching `\"plug\"` returns false"
+    (is (false? (sut/plug? (assoc hops/sample-hop :form "pELLET"))))
+    (is (false? (sut/plug? (assoc hops/sample-hop :form "lEAf"))))
+    (is (false? (sut/plug? (assoc hops/sample-hop cbf-hops/form cbf-hops/pellet))))
+    (is (false? (sut/plug? (assoc hops/sample-hop cbf-hops/form cbf-hops/leaf)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/plug? (assoc hops/sample-hop :form (hops/random-hop-form)))))
+    (is (boolean? (sut/plug? (assoc (hops/generate-hop) :form (hops/random-hop-form))))))
+  (testing "If the hop is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :form"
+                  (sut/plug? (dissoc hops/sample-hop :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :form"
+                   (sut/plug? (dissoc hops/sample-hop :form)))))))
+
+
+(deftest leaf?-test
+  (testing "A hop with a `:form` matching `\"leaf\"` returns true"
+    (is (true? (sut/leaf? (assoc hops/sample-hop :form "leaf"))))
+    (is (true? (sut/leaf? (assoc hops/sample-hop :form cbf-hops/leaf)))))
+  (testing "A hop with a `:form` not matching `\"leaf\"` returns false"
+    (is (false? (sut/leaf? (assoc hops/sample-hop :form "pELLET"))))
+    (is (false? (sut/leaf? (assoc hops/sample-hop :form "plug"))))
+    (is (false? (sut/leaf? (assoc hops/sample-hop :form cbf-hops/pellet))))
+    (is (false? (sut/leaf? (assoc hops/sample-hop :form cbf-hops/plug)))))
+  (testing "This is a function from a hop to a boolean"
+    (is (boolean? (sut/leaf? (assoc hops/sample-hop :form (hops/random-hop-form)))))
+    (is (boolean? (sut/leaf? (assoc (hops/generate-hop) :form (hops/random-hop-form))))))
+  (testing "If the hop is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Hop :form"
+                  (sut/leaf? (dissoc hops/sample-hop :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Hop :form"
+                   (sut/leaf? (dissoc hops/sample-hop :form)))))))

--- a/test/brewtility/predicates/impl_test.cljc
+++ b/test/brewtility/predicates/impl_test.cljc
@@ -1,0 +1,52 @@
+(ns brewtility.predicates.impl-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.predicates.impl :as sut]))
+
+
+(deftest fetch-or-throw!-test
+  (testing "Values are returned when present"
+    (is (true? (sut/fetch-or-throw! {:a true} :a "message")))
+    (is (false? (sut/fetch-or-throw! {:a false} :a "message")))
+    (is (= "some val" (sut/fetch-or-throw! {:some-key "some val"} :some-key "message"))))
+  (testing "Exceptions are thrown when values are missing"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"message"
+                  (sut/fetch-or-throw! {:a true} :b "message"))
+                "The user supplied message is included in the exception"))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"message"
+                   (sut/fetch-or-throw! {:a true} :b "message"))
+                 "The user supplied message is included in the exception"))
+    #?(:clj (is (= :missing-key
+                   (try (sut/fetch-or-throw! {:a true} :b "message")
+                        (catch Exception e (-> e ex-data :error-type))))
+                "The exception includes metadata indicating the type of error"))
+    #?(:cljs (is (= :missing-key
+                    (try (sut/fetch-or-throw! {:a true} :b "message")
+                         (catch js/Error e (-> e ex-data :error-type))))
+                 "The exception includes metadata indicating the type of error"))
+    #?(:clj (is (= :b
+                   (try (sut/fetch-or-throw! {:a true} :b "message")
+                        (catch Exception e (-> e ex-data :missing-key))))
+                "The exception's metadata indicates the missing key"))
+    #?(:cljs (is (= :b
+                    (try (sut/fetch-or-throw! {:a true} :b "message")
+                         (catch js/Error e (-> e ex-data :missing-key))))
+                 "The exception's metadata indicates the missing key"))
+    #?(:clj (is (= {:a true}
+                   (try (sut/fetch-or-throw! {:a true} :b "message")
+                        (catch Exception e (-> e ex-data :original-value))))
+                "The exception's metadata includes the original value"))
+    #?(:cljs (is (= {:a true}
+                    (try (sut/fetch-or-throw! {:a true} :b "message")
+                         (catch js/Error e (-> e ex-data :original-value))))
+                 "The exception's metadata includes the original value"))
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"message"
+                  (sut/fetch-or-throw! {:a nil} :a "message"))
+                "fetch-or-throw! treats nil values the same as missing keys"))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"message"
+                   (sut/fetch-or-throw! {:a nil} :a "message"))
+                 "fetch-or-throw! treats nil values the same as missing keys"))))

--- a/test/brewtility/predicates/mash_test.cljc
+++ b/test/brewtility/predicates/mash_test.cljc
@@ -1,0 +1,80 @@
+(ns brewtility.predicates.mash-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.mash :as mash]
+            [brewtility.predicates.mash :as sut]
+            [common-beer-format.mash :as cbf-mash]))
+
+
+(deftest adjust-for-equipment?-tests
+  (testing "When the `:equip-adjust` field is present, use that value"
+    (is (true? (sut/adjust-for-equipment? (assoc mash/sample-mash :equip-adjust true))))
+    (is (false? (sut/adjust-for-equipment? (assoc mash/sample-mash :equip-adjust false)))))
+  (testing "When the `:equip-adjust` field is missing, return false"
+    (is (false? (sut/adjust-for-equipment? (dissoc mash/sample-mash cbf-mash/equip-adjust)))))
+  (testing "This is a function from a mash to a boolean"
+    (is (boolean? (sut/adjust-for-equipment? mash/sample-mash)))
+    (is (boolean? (sut/adjust-for-equipment? (mash/generate-mash))))))
+
+
+(deftest infusion?-test
+  (testing "A mash-step with a `:type` matching `\"infusion\"` returns true"
+    (is (true? (sut/infusion? (assoc mash/sample-mash-step :type "INFUsion"))))
+    (is (true? (sut/infusion? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/infusion)))))
+  (testing "A mash-step with a `:type` not matching `\"infusion\"` returns false"
+    (is (false? (sut/infusion? (assoc mash/sample-mash-step :type "temperature"))))
+    (is (false? (sut/infusion? (assoc mash/sample-mash-step :type "decoction"))))
+    (is (false? (sut/infusion? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/temperature))))
+    (is (false? (sut/infusion? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/decoction)))))
+  (testing "This is a function from a mash-step to a boolean"
+    (is (boolean? (sut/infusion? mash/sample-mash-step)))
+    (is (boolean? (sut/infusion? (mash/generate-mash-step)))))
+  (testing "If the mash-step is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Mash step :type"
+                  (sut/infusion? (dissoc mash/sample-mash-step :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Mash step :type"
+                   (sut/infusion? (dissoc mash/sample-mash-step :type)))))))
+
+
+(deftest temperature?-test
+  (testing "A mash-step with a `:type` matching `\"temperature\"` returns true"
+    (is (true? (sut/temperature? (assoc mash/sample-mash-step :type "temperature"))))
+    (is (true? (sut/temperature? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/temperature)))))
+  (testing "A mash-step with a `:type` not matching `\"temperature\"` returns false"
+    (is (false? (sut/temperature? (assoc mash/sample-mash-step :type "infusion"))))
+    (is (false? (sut/temperature? (assoc mash/sample-mash-step :type "decoction"))))
+    (is (false? (sut/temperature? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/infusion))))
+    (is (false? (sut/temperature? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/decoction)))))
+  (testing "This is a function from a mash-step to a boolean"
+    (is (boolean? (sut/temperature? mash/sample-mash-step)))
+    (is (boolean? (sut/temperature? (mash/generate-mash-step)))))
+  (testing "If the mash-step is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Mash step :type"
+                  (sut/temperature? (dissoc mash/sample-mash-step :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Mash step :type"
+                   (sut/temperature? (dissoc mash/sample-mash-step :type)))))))
+
+
+(deftest decoction?-test
+  (testing "A mash-step with a `:type` matching `\"decoction\"` returns true"
+    (is (true? (sut/decoction? (assoc mash/sample-mash-step :type "decoction"))))
+    (is (true? (sut/decoction? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/decoction)))))
+  (testing "A mash-step with a `:type` not matching `\"decoction\"` returns false"
+    (is (false? (sut/decoction? (assoc mash/sample-mash-step :type "infusion"))))
+    (is (false? (sut/decoction? (assoc mash/sample-mash-step :type "TEMPERature"))))
+    (is (false? (sut/decoction? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/infusion))))
+    (is (false? (sut/decoction? (assoc mash/sample-mash-step cbf-mash/type cbf-mash/temperature)))))
+  (testing "This is a function from a mash-step to a boolean"
+    (is (boolean? (sut/decoction? mash/sample-mash-step)))
+    (is (boolean? (sut/decoction? (mash/generate-mash-step)))))
+  (testing "If the mash-step is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Mash step :type"
+                  (sut/decoction? (dissoc mash/sample-mash-step :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Mash step :type"
+                   (sut/decoction? (dissoc mash/sample-mash-step :type)))))))

--- a/test/brewtility/predicates/miscs_test.cljc
+++ b/test/brewtility/predicates/miscs_test.cljc
@@ -1,0 +1,301 @@
+(ns brewtility.predicates.miscs-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.miscs :as miscs]
+            [brewtility.predicates.miscs :as sut]
+            [common-beer-format.miscs :as cbf-miscs]))
+
+
+;;
+;; :type function tests
+;;
+
+(deftest spice?-test
+  (testing "A misc with a `:type` matching `\"spice\"` returns true"
+    (is (true? (sut/spice? (assoc miscs/sample-misc :type "SPiCE"))))
+    (is (true? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice)))))
+  (testing "A misc with a `:type` not matching `\"spice\"` returns false"
+    (is (false? (sut/spice? (assoc miscs/sample-misc :type "fining"))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc :type "water agent"))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc :type "herb"))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc :type "flavor"))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc :type "other"))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor))))
+    (is (false? (sut/spice? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/spice? miscs/sample-misc)))
+    (is (boolean? (sut/spice? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/spice? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/spice? (dissoc miscs/sample-misc :type)))))))
+
+
+(deftest fining?-test
+  (testing "A misc with a `:type` matching `\"fining\"` returns true"
+    (is (true? (sut/fining? (assoc miscs/sample-misc :type "fining"))))
+    (is (true? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining)))))
+  (testing "A misc with a `:type` not matching `\"fining\"` returns false"
+    (is (false? (sut/fining? (assoc miscs/sample-misc :type "spice"))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc :type "water agent"))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc :type "herb"))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc :type "flavor"))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc :type "other"))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor))))
+    (is (false? (sut/fining? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/fining? miscs/sample-misc)))
+    (is (boolean? (sut/fining? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/fining? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/fining? (dissoc miscs/sample-misc :type)))))))
+
+
+(deftest water-agent?-test
+  (testing "A misc with a `:type` matching `\"water-agent\"` returns true"
+    (is (true? (sut/water-agent? (assoc miscs/sample-misc :type "water agent"))))
+    (is (true? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent)))))
+  (testing "A misc with a `:type` not matching `\"water-agent\"` returns false"
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc :type "spice"))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc :type "other"))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc :type "fining"))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc :type "herb"))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc :type "flavor"))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb))))
+    (is (false? (sut/water-agent? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/water-agent? miscs/sample-misc)))
+    (is (boolean? (sut/water-agent? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/water-agent? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/water-agent? (dissoc miscs/sample-misc :type)))))))
+
+
+(deftest herb?-test
+  (testing "A misc with a `:type` matching `\"herb\"` returns true"
+    (is (true? (sut/herb? (assoc miscs/sample-misc :type "herb"))))
+    (is (true? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb)))))
+  (testing "A misc with a `:type` not matching `\"herb\"` returns false"
+    (is (false? (sut/herb? (assoc miscs/sample-misc :type "spice"))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc :type "water agent"))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc :type "fining"))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc :type "flavor"))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc :type "other"))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor))))
+    (is (false? (sut/herb? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/herb? miscs/sample-misc)))
+    (is (boolean? (sut/herb? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/herb? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/herb? (dissoc miscs/sample-misc :type)))))))
+
+
+(deftest flavor?-test
+  (testing "A misc with a `:type` matching `\"flavor\"` returns true"
+    (is (true? (sut/flavor? (assoc miscs/sample-misc :type "flavor"))))
+    (is (true? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor)))))
+  (testing "A misc with a `:type` not matching `\"flavor\"` returns false"
+    (is (false? (sut/flavor? (assoc miscs/sample-misc :type "spice"))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc :type "water agent"))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc :type "fining"))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc :type "herb"))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc :type "other"))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb))))
+    (is (false? (sut/flavor? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/flavor? miscs/sample-misc)))
+    (is (boolean? (sut/flavor? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/flavor? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/flavor? (dissoc miscs/sample-misc :type)))))))
+
+
+(deftest other?-test
+  (testing "A misc with a `:type` matching `\"other\"` returns true"
+    (is (true? (sut/other? (assoc miscs/sample-misc :type "other"))))
+    (is (true? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/other)))))
+  (testing "A misc with a `:type` not matching `\"other\"` returns false"
+    (is (false? (sut/other? (assoc miscs/sample-misc :type "spice"))))
+    (is (false? (sut/other? (assoc miscs/sample-misc :type "water agent"))))
+    (is (false? (sut/other? (assoc miscs/sample-misc :type "fining"))))
+    (is (false? (sut/other? (assoc miscs/sample-misc :type "herb"))))
+    (is (false? (sut/other? (assoc miscs/sample-misc :type "flavor"))))
+    (is (false? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/spice))))
+    (is (false? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/water-agent))))
+    (is (false? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/fining))))
+    (is (false? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/herb))))
+    (is (false? (sut/other? (assoc miscs/sample-misc cbf-miscs/type cbf-miscs/flavor)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/other? miscs/sample-misc)))
+    (is (boolean? (sut/other? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :type"
+                  (sut/other? (dissoc miscs/sample-misc :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :type"
+                   (sut/other? (dissoc miscs/sample-misc :type)))))))
+
+
+;;
+;; :use function tests
+;;
+
+(deftest boil?-test
+  (testing "A misc with a `:use` matching `\"boil\"` returns true"
+    (is (true? (sut/boil? (assoc miscs/sample-misc :use "boil"))))
+    (is (true? (sut/boil? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/boil)))))
+  (testing "A misc with a `:use` not matching `\"boil\"` returns false"
+    (is (false? (sut/boil? (assoc miscs/sample-misc :use "mash"))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc :use "primary"))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc :use "secondary"))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc :use "bottling"))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/mash))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/primary))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/secondary))))
+    (is (false? (sut/boil? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/bottling)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/boil? miscs/sample-misc)))
+    (is (boolean? (sut/boil? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :use"
+                  (sut/boil? (dissoc miscs/sample-misc :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :use"
+                   (sut/boil? (dissoc miscs/sample-misc :use)))))))
+
+
+(deftest mash?-test
+  (testing "A misc with a `:use` matching `\"mash\"` returns true"
+    (is (true? (sut/mash? (assoc miscs/sample-misc :use "mash"))))
+    (is (true? (sut/mash? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/mash)))))
+  (testing "A misc with a `:use` not matching `\"mash\"` returns false"
+    (is (false? (sut/mash? (assoc miscs/sample-misc :use "boil"))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc :use "primary"))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc :use "secondary"))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc :use "bottling"))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/boil))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/primary))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/secondary))))
+    (is (false? (sut/mash? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/bottling)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/mash? miscs/sample-misc)))
+    (is (boolean? (sut/mash? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :use"
+                  (sut/mash? (dissoc miscs/sample-misc :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :use"
+                   (sut/mash? (dissoc miscs/sample-misc :use)))))))
+
+
+(deftest primary?-test
+  (testing "A misc with a `:use` matching `\"primary\"` returns true"
+    (is (true? (sut/primary? (assoc miscs/sample-misc :use "primary"))))
+    (is (true? (sut/primary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/primary)))))
+  (testing "A misc with a `:use` not matching `\"primary\"` returns false"
+    (is (false? (sut/primary? (assoc miscs/sample-misc :use "boil"))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc :use "mash"))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc :use "secondary"))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc :use "bottling"))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/boil))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/mash))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/secondary))))
+    (is (false? (sut/primary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/bottling)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/primary? miscs/sample-misc)))
+    (is (boolean? (sut/primary? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :use"
+                  (sut/primary? (dissoc miscs/sample-misc :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :use"
+                   (sut/primary? (dissoc miscs/sample-misc :use)))))))
+
+
+(deftest secondary?-test
+  (testing "A misc with a `:use` matching `\"secondary\"` returns true"
+    (is (true? (sut/secondary? (assoc miscs/sample-misc :use "secondary"))))
+    (is (true? (sut/secondary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/secondary)))))
+  (testing "A misc with a `:use` not matching `\"secondary\"` returns false"
+    (is (false? (sut/secondary? (assoc miscs/sample-misc :use "boil"))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc :use "mash"))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc :use "primary"))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc :use "bottling"))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/boil))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/mash))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/primary))))
+    (is (false? (sut/secondary? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/bottling)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/secondary? miscs/sample-misc)))
+    (is (boolean? (sut/secondary? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :use"
+                  (sut/secondary? (dissoc miscs/sample-misc :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :use"
+                   (sut/secondary? (dissoc miscs/sample-misc :use)))))))
+
+
+(deftest bottling?-test
+  (testing "A misc with a `:use` matching `\"bottling\"` returns true"
+    (is (true? (sut/bottling? (assoc miscs/sample-misc :use "bottling"))))
+    (is (true? (sut/bottling? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/bottling)))))
+  (testing "A misc with a `:use` not matching `\"bottling\"` returns false"
+    (is (false? (sut/bottling? (assoc miscs/sample-misc :use "boil"))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc :use "mash"))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc :use "primary"))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc :use "secondary"))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/boil))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/mash))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/primary))))
+    (is (false? (sut/bottling? (assoc miscs/sample-misc cbf-miscs/use cbf-miscs/secondary)))))
+  (testing "This is a function from a misc to a boolean"
+    (is (boolean? (sut/bottling? miscs/sample-misc)))
+    (is (boolean? (sut/bottling? (miscs/generate-misc)))))
+  (testing "If the misc is missing `:use`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Misc :use"
+                  (sut/bottling? (dissoc miscs/sample-misc :use)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Misc :use"
+                   (sut/bottling? (dissoc miscs/sample-misc :use)))))))

--- a/test/brewtility/predicates/recipes_test.cljc
+++ b/test/brewtility/predicates/recipes_test.cljc
@@ -1,0 +1,159 @@
+(ns brewtility.predicates.recipes-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.recipes :as recipes]
+            [brewtility.predicates.recipes :as sut]
+            [common-beer-format.recipes :as cbf-recipes]))
+
+
+;;
+;; Boolean function test
+;;
+
+(deftest forced-carbonation?-tests
+  (testing "When the `:forced-carbonation` field is present, use that value"
+    (is (true? (sut/forced-carbonation? (assoc recipes/sample-recipe :forced-carbonation true))))
+    (is (false? (sut/forced-carbonation? (assoc recipes/sample-recipe :forced-carbonation false))))
+    (is (true? (sut/forced-carbonation? (assoc recipes/sample-recipe cbf-recipes/forced-carbonation true))))
+    (is (false? (sut/forced-carbonation? (assoc recipes/sample-recipe cbf-recipes/forced-carbonation false)))))
+  (testing "When the `:forced-carbonation` field is missing, return false"
+    (is (false? (sut/forced-carbonation? (dissoc recipes/sample-recipe :forced-carbonation)))))
+  (testing "This is a function from a fermentable to a boolean"
+    (is (boolean? (sut/forced-carbonation? recipes/sample-recipe)))
+    (is (boolean? (sut/forced-carbonation? (recipes/generate-recipe))))))
+
+
+;;
+;; :type function tests
+;;
+
+(deftest extract?-test
+  (testing "A recipe with a `:type` matching `\"extract\"` returns true"
+    (is (true? (sut/extract? (assoc recipes/sample-recipe :type "extract"))))
+    (is (true? (sut/extract? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/extract)))))
+  (testing "A recipe with a `:type` not matching `\"extract\"` returns false"
+    (is (false? (sut/extract? (assoc recipes/sample-recipe :type "all grain"))))
+    (is (false? (sut/extract? (assoc recipes/sample-recipe :type "partial mash"))))
+    (is (false? (sut/extract? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/all-grain))))
+    (is (false? (sut/extract? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/partial-mash)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/extract? recipes/sample-recipe)))
+    (is (boolean? (sut/extract? (recipes/generate-recipe)))))
+  (testing "If the recipe is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :type"
+                  (sut/extract? (dissoc recipes/sample-recipe :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :type"
+                   (sut/extract? (dissoc recipes/sample-recipe :type)))))))
+
+
+(deftest all-grain?-test
+  (testing "A recipe with a `:type` matching `\"all-grain\"` returns true"
+    (is (true? (sut/all-grain? (assoc recipes/sample-recipe :type "all grain"))))
+    (is (true? (sut/all-grain? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/all-grain)))))
+  (testing "A recipe with a `:type` not matching `\"all-grain\"` returns false"
+    (is (false? (sut/all-grain? (assoc recipes/sample-recipe :type "extract"))))
+    (is (false? (sut/all-grain? (assoc recipes/sample-recipe :type "partial mash"))))
+    (is (false? (sut/all-grain? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/extract))))
+    (is (false? (sut/all-grain? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/partial-mash)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/all-grain? recipes/sample-recipe)))
+    (is (boolean? (sut/all-grain? (recipes/generate-recipe)))))
+  (testing "If the recipe is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :type"
+                  (sut/all-grain? (dissoc recipes/sample-recipe :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :type"
+                   (sut/all-grain? (dissoc recipes/sample-recipe :type)))))))
+
+
+(deftest partial-mash?-test
+  (testing "A recipe with a `:type` matching `\"partial-mash\"` returns true"
+    (is (true? (sut/partial-mash? (assoc recipes/sample-recipe :type "partial mash"))))
+    (is (true? (sut/partial-mash? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/partial-mash)))))
+  (testing "A recipe with a `:type` not matching `\"partial-mash\"` returns false"
+    (is (false? (sut/partial-mash? (assoc recipes/sample-recipe :type "extract"))))
+    (is (false? (sut/partial-mash? (assoc recipes/sample-recipe :type "all grain"))))
+    (is (false? (sut/partial-mash? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/extract))))
+    (is (false? (sut/partial-mash? (assoc recipes/sample-recipe cbf-recipes/type cbf-recipes/all-grain)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/partial-mash? recipes/sample-recipe)))
+    (is (boolean? (sut/partial-mash? (recipes/generate-recipe)))))
+  (testing "If the recipe is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :type"
+                  (sut/partial-mash? (dissoc recipes/sample-recipe :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :type"
+                   (sut/partial-mash? (dissoc recipes/sample-recipe :type)))))))
+
+
+;;
+;; :ibu-method function tests
+;;
+
+(deftest rager?-test
+  (testing "A recipe with a `:ibu-method` matching `\"rager\"` returns true"
+    (is (true? (sut/rager? (assoc recipes/sample-recipe :ibu-method "rager"))))
+    (is (true? (sut/rager? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/rager)))))
+  (testing "A recipe with a `:ibu-method` not matching `\"rager\"` returns false"
+    (is (false? (sut/rager? (assoc recipes/sample-recipe :ibu-method "tinseth"))))
+    (is (false? (sut/rager? (assoc recipes/sample-recipe :ibu-method "garetz"))))
+    (is (false? (sut/rager? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/tinseth))))
+    (is (false? (sut/rager? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/garetz)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/rager? (assoc recipes/sample-recipe :ibu-method (recipes/random-ibu-method)))))
+    (is (boolean? (sut/rager? (assoc (recipes/generate-recipe) :ibu-method (recipes/random-ibu-method))))))
+  (testing "If the recipe is missing `:ibu-method`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :ibu-method"
+                  (sut/rager? (dissoc recipes/sample-recipe :ibu-method)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :ibu-method"
+                   (sut/rager? (dissoc recipes/sample-recipe :ibu-method)))))))
+
+
+(deftest tinseth?-test
+  (testing "A recipe with a `:ibu-method` matching `\"tinseth\"` returns true"
+    (is (true? (sut/tinseth? (assoc recipes/sample-recipe :ibu-method "tinseth"))))
+    (is (true? (sut/tinseth? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/tinseth)))))
+  (testing "A recipe with a `:ibu-method` not matching `\"tinseth\"` returns false"
+    (is (false? (sut/tinseth? (assoc recipes/sample-recipe :ibu-method "rager"))))
+    (is (false? (sut/tinseth? (assoc recipes/sample-recipe :ibu-method "garetz"))))
+    (is (false? (sut/tinseth? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/rager))))
+    (is (false? (sut/tinseth? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/garetz)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/tinseth? (assoc recipes/sample-recipe :ibu-method (recipes/random-ibu-method)))))
+    (is (boolean? (sut/tinseth? (assoc (recipes/generate-recipe) :ibu-method (recipes/random-ibu-method))))))
+  (testing "If the recipe is missing `:ibu-method`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :ibu-method"
+                  (sut/tinseth? (dissoc recipes/sample-recipe :ibu-method)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :ibu-method"
+                   (sut/tinseth? (dissoc recipes/sample-recipe :ibu-method)))))))
+
+
+(deftest garetz?-test
+  (testing "A recipe with a `:ibu-method` matching `\"garetz\"` returns true"
+    (is (true? (sut/garetz? (assoc recipes/sample-recipe :ibu-method "garetz"))))
+    (is (true? (sut/garetz? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/garetz)))))
+  (testing "A recipe with a `:ibu-method` not matching `\"garetz\"` returns false"
+    (is (false? (sut/garetz? (assoc recipes/sample-recipe :ibu-method "rager"))))
+    (is (false? (sut/garetz? (assoc recipes/sample-recipe :ibu-method "tinseth"))))
+    (is (false? (sut/garetz? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/rager))))
+    (is (false? (sut/garetz? (assoc recipes/sample-recipe cbf-recipes/ibu-method cbf-recipes/tinseth)))))
+  (testing "This is a function from a recipe to a boolean"
+    (is (boolean? (sut/garetz? (assoc recipes/sample-recipe :ibu-method (recipes/random-ibu-method)))))
+    (is (boolean? (sut/garetz? (assoc (recipes/generate-recipe) :ibu-method (recipes/random-ibu-method))))))
+  (testing "If the recipe is missing `:ibu-method`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Recipe :ibu-method"
+                  (sut/garetz? (dissoc recipes/sample-recipe :ibu-method)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Recipe :ibu-method"
+                   (sut/garetz? (dissoc recipes/sample-recipe :ibu-method)))))))
+
+

--- a/test/brewtility/predicates/styles_test.cljc
+++ b/test/brewtility/predicates/styles_test.cljc
@@ -1,0 +1,172 @@
+(ns brewtility.predicates.styles-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.styles :as styles]
+            [brewtility.predicates.styles :as sut]
+            [common-beer-format.styles :as cbf-styles]))
+
+
+;;
+;; :type function tests
+;;
+
+(deftest lager?-test
+  (testing "A style with a `:type` matching `\"lager\"` returns true"
+    (is (true? (sut/lager? (assoc styles/sample-style :type "lager"))))
+    (is (true? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/lager)))))
+  (testing "A style with a `:type` not matching `\"lager\"` returns false"
+    (is (false? (sut/lager? (assoc styles/sample-style :type "ale"))))
+    (is (false? (sut/lager? (assoc styles/sample-style :type "mead"))))
+    (is (false? (sut/lager? (assoc styles/sample-style :type "wheat"))))
+    (is (false? (sut/lager? (assoc styles/sample-style :type "mixed"))))
+    (is (false? (sut/lager? (assoc styles/sample-style :type "cider"))))
+    (is (false? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/ale))))
+    (is (false? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/mead))))
+    (is (false? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat))))
+    (is (false? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed))))
+    (is (false? (sut/lager? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/lager? styles/sample-style)))
+    (is (boolean? (sut/lager? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/lager? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/lager? (dissoc styles/sample-style :type)))))))
+
+
+(deftest ale?-test
+  (testing "A style with a `:type` matching `\"ale\"` returns true"
+    (is (true? (sut/ale? (assoc styles/sample-style :type "ale"))))
+    (is (true? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/ale)))))
+  (testing "A style with a `:type` not matching `\"ale\"` returns false"
+    (is (false? (sut/ale? (assoc styles/sample-style :type "lager"))))
+    (is (false? (sut/ale? (assoc styles/sample-style :type "mead"))))
+    (is (false? (sut/ale? (assoc styles/sample-style :type "wheat"))))
+    (is (false? (sut/ale? (assoc styles/sample-style :type "mixed"))))
+    (is (false? (sut/ale? (assoc styles/sample-style :type "cider"))))
+    (is (false? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/lager))))
+    (is (false? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/mead))))
+    (is (false? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat))))
+    (is (false? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed))))
+    (is (false? (sut/ale? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/ale? styles/sample-style)))
+    (is (boolean? (sut/ale? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/ale? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/ale? (dissoc styles/sample-style :type)))))))
+
+
+(deftest mead?-test
+  (testing "A style with a `:type` matching `\"mead\"` returns true"
+    (is (true? (sut/mead? (assoc styles/sample-style :type "mead"))))
+    (is (true? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/mead)))))
+  (testing "A style with a `:type` not matching `\"mead\"` returns false"
+    (is (false? (sut/mead? (assoc styles/sample-style :type "lager"))))
+    (is (false? (sut/mead? (assoc styles/sample-style :type "ale"))))
+    (is (false? (sut/mead? (assoc styles/sample-style :type "wheat"))))
+    (is (false? (sut/mead? (assoc styles/sample-style :type "mixed"))))
+    (is (false? (sut/mead? (assoc styles/sample-style :type "cider"))))
+    (is (false? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/lager))))
+    (is (false? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/ale))))
+    (is (false? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat))))
+    (is (false? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed))))
+    (is (false? (sut/mead? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/mead? styles/sample-style)))
+    (is (boolean? (sut/mead? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/mead? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/mead? (dissoc styles/sample-style :type)))))))
+
+
+(deftest wheat?-test
+  (testing "A style with a `:type` matching `\"wheat\"` returns true"
+    (is (true? (sut/wheat? (assoc styles/sample-style :type "wheat"))))
+    (is (true? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat)))))
+  (testing "A style with a `:type` not matching `\"wheat\"` returns false"
+    (is (false? (sut/wheat? (assoc styles/sample-style :type "lager"))))
+    (is (false? (sut/wheat? (assoc styles/sample-style :type "ale"))))
+    (is (false? (sut/wheat? (assoc styles/sample-style :type "mead"))))
+    (is (false? (sut/wheat? (assoc styles/sample-style :type "mixed"))))
+    (is (false? (sut/wheat? (assoc styles/sample-style :type "cider"))))
+    (is (false? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/lager))))
+    (is (false? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/ale))))
+    (is (false? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/mead))))
+    (is (false? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed))))
+    (is (false? (sut/wheat? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/wheat? styles/sample-style)))
+    (is (boolean? (sut/wheat? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/wheat? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/wheat? (dissoc styles/sample-style :type)))))))
+
+
+(deftest mixed?-test
+  (testing "A style with a `:type` matching `\"mixed\"` returns true"
+    (is (true? (sut/mixed? (assoc styles/sample-style :type "mixed"))))
+    (is (true? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed)))))
+  (testing "A style with a `:type` not matching `\"mixed\"` returns false"
+    (is (false? (sut/mixed? (assoc styles/sample-style :type "lager"))))
+    (is (false? (sut/mixed? (assoc styles/sample-style :type "ale"))))
+    (is (false? (sut/mixed? (assoc styles/sample-style :type "mead"))))
+    (is (false? (sut/mixed? (assoc styles/sample-style :type "wheat"))))
+    (is (false? (sut/mixed? (assoc styles/sample-style :type "cider"))))
+    (is (false? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/lager))))
+    (is (false? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/ale))))
+    (is (false? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/mead))))
+    (is (false? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat))))
+    (is (false? (sut/mixed? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/mixed? styles/sample-style)))
+    (is (boolean? (sut/mixed? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/mixed? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/mixed? (dissoc styles/sample-style :type)))))))
+
+
+(deftest cider?-test
+  (testing "A style with a `:type` matching `\"cider\"` returns true"
+    (is (true? (sut/cider? (assoc styles/sample-style :type "cider"))))
+    (is (true? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/cider)))))
+  (testing "A style with a `:type` not matching `\"cider\"` returns false"
+    (is (false? (sut/cider? (assoc styles/sample-style :type "lager"))))
+    (is (false? (sut/cider? (assoc styles/sample-style :type "ale"))))
+    (is (false? (sut/cider? (assoc styles/sample-style :type "mead"))))
+    (is (false? (sut/cider? (assoc styles/sample-style :type "wheat"))))
+    (is (false? (sut/cider? (assoc styles/sample-style :type "mixed"))))
+    (is (false? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/lager))))
+    (is (false? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/ale))))
+    (is (false? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/mead))))
+    (is (false? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/wheat))))
+    (is (false? (sut/cider? (assoc styles/sample-style cbf-styles/type cbf-styles/mixed)))))
+  (testing "This is a function from a style to a boolean"
+    (is (boolean? (sut/cider? styles/sample-style)))
+    (is (boolean? (sut/cider? (styles/generate-style)))))
+  (testing "If the style is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Style :type"
+                  (sut/cider? (dissoc styles/sample-style :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Style :type"
+                   (sut/cider? (dissoc styles/sample-style :type)))))))

--- a/test/brewtility/predicates/waters_test.cljc
+++ b/test/brewtility/predicates/waters_test.cljc
@@ -1,0 +1,79 @@
+(ns brewtility.predicates.waters-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.waters :as waters]
+            [brewtility.predicates.waters :as sut]
+            [common-beer-format.waters :as cbf-waters]))
+
+
+;;
+;; :ph function tests
+;;
+
+(deftest acidic?-test
+  (testing "A water with a `:ph` beneath `7` returns true"
+    (is (true? (sut/acidic? (assoc waters/sample-water :ph 6))))
+    (is (true? (sut/acidic? (assoc waters/sample-water cbf-waters/ph 6)))))
+  (testing "A water with a `:ph` equal to or above `7` returns false"
+    (is (false? (sut/acidic? (assoc waters/sample-water :ph 7))))
+    (is (false? (sut/acidic? (assoc waters/sample-water :ph 7.0))))
+    (is (false? (sut/acidic? (assoc waters/sample-water :ph 9))))
+    (is (false? (sut/acidic? (assoc waters/sample-water cbf-waters/ph 7))))
+    (is (false? (sut/acidic? (assoc waters/sample-water cbf-waters/ph 7.0))))
+    (is (false? (sut/acidic? (assoc waters/sample-water cbf-waters/ph 9)))))
+  (testing "This is a function from a water to a boolean"
+    (is (boolean? (sut/acidic? (assoc waters/sample-water :ph (waters/random-ph)))))
+    (is (boolean? (sut/acidic? (assoc (waters/generate-water) :ph (waters/random-ph))))))
+  (testing "If the water is missing `:ph`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Water `:ph`"
+                  (sut/acidic? (dissoc waters/sample-water :ph)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Water `:ph`"
+                   (sut/acidic? (dissoc waters/sample-water :ph)))))))
+
+
+(deftest alkaline?-test
+  (testing "A water with a `:ph` above `7` returns true"
+    (is (true? (sut/alkaline? (assoc waters/sample-water :ph 9))))
+    (is (true? (sut/alkaline? (assoc waters/sample-water cbf-waters/ph 9)))))
+  (testing "A water with a `:ph` equal to or beneath `7` returns false"
+    (is (false? (sut/alkaline? (assoc waters/sample-water :ph 7))))
+    (is (false? (sut/alkaline? (assoc waters/sample-water :ph 7.0))))
+    (is (false? (sut/alkaline? (assoc waters/sample-water :ph 2))))
+    (is (false? (sut/alkaline? (assoc waters/sample-water cbf-waters/ph 7))))
+    (is (false? (sut/alkaline? (assoc waters/sample-water cbf-waters/ph 7.0))))
+    (is (false? (sut/alkaline? (assoc waters/sample-water cbf-waters/ph 2)))))
+  (testing "This is a function from a water to a boolean"
+    (is (boolean? (sut/alkaline? (assoc waters/sample-water :ph (waters/random-ph)))))
+    (is (boolean? (sut/alkaline? (assoc (waters/generate-water) :ph (waters/random-ph))))))
+  (testing "If the water is missing `:ph`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Water `:ph`"
+                  (sut/alkaline? (dissoc waters/sample-water :ph)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Water `:ph`"
+                   (sut/alkaline? (dissoc waters/sample-water :ph)))))))
+
+
+(deftest neutral?-test
+  (testing "A water with a `:ph` equal to `7` returns true"
+    (is (true? (sut/neutral? (assoc waters/sample-water :ph 7))))
+    (is (true? (sut/neutral? (assoc waters/sample-water :ph 7.0))))
+    (is (true? (sut/neutral? (assoc waters/sample-water cbf-waters/ph 7))))
+    (is (true? (sut/neutral? (assoc waters/sample-water cbf-waters/ph 7.0)))))
+  (testing "A water with a `:ph` not equal to `7` returns false"
+    (is (false? (sut/neutral? (assoc waters/sample-water :ph 2))))
+    (is (false? (sut/neutral? (assoc waters/sample-water :ph 9))))
+    (is (false? (sut/neutral? (assoc waters/sample-water cbf-waters/ph 2))))
+    (is (false? (sut/neutral? (assoc waters/sample-water cbf-waters/ph 9)))))
+  (testing "This is a function from a water to a boolean"
+    (is (boolean? (sut/neutral? (assoc waters/sample-water :ph (waters/random-ph)))))
+    (is (boolean? (sut/neutral? (assoc (waters/generate-water) :ph (waters/random-ph))))))
+  (testing "If the water is missing `:ph`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Water `:ph`"
+                  (sut/neutral? (dissoc waters/sample-water :ph)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Water `:ph`"
+                   (sut/neutral? (dissoc waters/sample-water :ph)))))))

--- a/test/brewtility/predicates/yeasts_test.cljc
+++ b/test/brewtility/predicates/yeasts_test.cljc
@@ -1,0 +1,327 @@
+(ns brewtility.predicates.yeasts-test
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.yeasts :as yeasts]
+            [brewtility.predicates.yeasts :as sut]
+            [common-beer-format.yeasts :as cbf-yeasts]))
+
+
+;;
+;; :type function tests
+;;
+
+(deftest lager?-test
+  (testing "A yeast with a `:type` matching `\"lager\"` returns true"
+    (is (true? (sut/lager? (assoc yeasts/sample-yeast :type "lager"))))
+    (is (true? (sut/lager? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/lager)))))
+  (testing "A yeast with a `:type` not matching `\"lager\"` returns false"
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast :type "ale"))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast :type "wheat"))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast :type "wine"))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast :type "champagne"))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/ale))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wheat))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wine))))
+    (is (false? (sut/lager? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/champagne)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/lager? yeasts/sample-yeast)))
+    (is (boolean? (sut/lager? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :type"
+                  (sut/lager? (dissoc yeasts/sample-yeast :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :type"
+                   (sut/lager? (dissoc yeasts/sample-yeast :type)))))))
+
+
+(deftest ale?-test
+  (testing "A yeast with a `:type` matching `\"ale\"` returns true"
+    (is (true? (sut/ale? (assoc yeasts/sample-yeast :type "ale"))))
+    (is (true? (sut/ale? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/ale)))))
+  (testing "A yeast with a `:type` not matching `\"ale\"` returns false"
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast :type "lager"))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast :type "wheat"))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast :type "wine"))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast :type "champagne"))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/lager))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wheat))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wine))))
+    (is (false? (sut/ale? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/champagne)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/ale? yeasts/sample-yeast)))
+    (is (boolean? (sut/ale? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :type"
+                  (sut/ale? (dissoc yeasts/sample-yeast :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :type"
+                   (sut/ale? (dissoc yeasts/sample-yeast :type)))))))
+
+
+(deftest wheat?-test
+  (testing "A yeast with a `:type` matching `\"wheat\"` returns true"
+    (is (true? (sut/wheat? (assoc yeasts/sample-yeast :type "wheat"))))
+    (is (true? (sut/wheat? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wheat)))))
+  (testing "A yeast with a `:type` not matching `\"wheat\"` returns false"
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast :type "lager"))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast :type "ale"))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast :type "wine"))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast :type "champagne"))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/lager))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/ale))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wine))))
+    (is (false? (sut/wheat? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/champagne)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/wheat? yeasts/sample-yeast)))
+    (is (boolean? (sut/wheat? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :type"
+                  (sut/wheat? (dissoc yeasts/sample-yeast :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :type"
+                   (sut/wheat? (dissoc yeasts/sample-yeast :type)))))))
+
+
+(deftest wine?-test
+  (testing "A yeast with a `:type` matching `\"wine\"` returns true"
+    (is (true? (sut/wine? (assoc yeasts/sample-yeast :type "wine"))))
+    (is (true? (sut/wine? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wine)))))
+  (testing "A yeast with a `:type` not matching `\"wine\"` returns false"
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast :type "lager"))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast :type "ale"))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast :type "wheat"))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast :type "champagne"))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/lager))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/ale))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wheat))))
+    (is (false? (sut/wine? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/champagne)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/wine? yeasts/sample-yeast)))
+    (is (boolean? (sut/wine? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :type"
+                  (sut/wine? (dissoc yeasts/sample-yeast :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :type"
+                   (sut/wine? (dissoc yeasts/sample-yeast :type)))))))
+
+
+(deftest champagne?-test
+  (testing "A yeast with a `:type` matching `\"champagne\"` returns true"
+    (is (true? (sut/champagne? (assoc yeasts/sample-yeast :type "champagne"))))
+    (is (true? (sut/champagne? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/champagne)))))
+  (testing "A yeast with a `:type` not matching `\"champagne\"` returns false"
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast :type "lager"))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast :type "ale"))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast :type "wheat"))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast :type "wine"))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/lager))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/ale))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wheat))))
+    (is (false? (sut/champagne? (assoc yeasts/sample-yeast cbf-yeasts/type cbf-yeasts/wine)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/champagne? yeasts/sample-yeast)))
+    (is (boolean? (sut/champagne? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:type`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :type"
+                  (sut/champagne? (dissoc yeasts/sample-yeast :type)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :type"
+                   (sut/champagne? (dissoc yeasts/sample-yeast :type)))))))
+
+
+;;
+;; :form function tests
+;;
+
+(deftest liquid?-test
+  (testing "A yeast with a `:form` matching `\"liquid\"` returns true"
+    (is (true? (sut/liquid? (assoc yeasts/sample-yeast :form "liquid"))))
+    (is (true? (sut/liquid? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/liquid)))))
+  (testing "A yeast with a `:form` not matching `\"liquid\"` returns false"
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast :form "dry"))))
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast :form "slant"))))
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast :form "culture"))))
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/dry))))
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/slant))))
+    (is (false? (sut/liquid? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/culture)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/liquid? yeasts/sample-yeast)))
+    (is (boolean? (sut/liquid? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :form"
+                  (sut/liquid? (dissoc yeasts/sample-yeast :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :form"
+                   (sut/liquid? (dissoc yeasts/sample-yeast :form)))))))
+
+
+(deftest dry?-test
+  (testing "A yeast with a `:form` matching `\"dry\"` returns true"
+    (is (true? (sut/dry? (assoc yeasts/sample-yeast :form "dry"))))
+    (is (true? (sut/dry? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/dry)))))
+  (testing "A yeast with a `:form` not matching `\"dry\"` returns false"
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast :form "liquid"))))
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast :form "slant"))))
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast :form "culture"))))
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/liquid))))
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/slant))))
+    (is (false? (sut/dry? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/culture)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/dry? yeasts/sample-yeast)))
+    (is (boolean? (sut/dry? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :form"
+                  (sut/dry? (dissoc yeasts/sample-yeast :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :form"
+                   (sut/dry? (dissoc yeasts/sample-yeast :form)))))))
+
+
+(deftest slant?-test
+  (testing "A yeast with a `:form` matching `\"slant\"` returns true"
+    (is (true? (sut/slant? (assoc yeasts/sample-yeast :form "slant"))))
+    (is (true? (sut/slant? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/slant)))))
+  (testing "A yeast with a `:form` not matching `\"slant\"` returns false"
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast :form "liquid"))))
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast :form "dry"))))
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast :form "culture"))))
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/liquid))))
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/dry))))
+    (is (false? (sut/slant? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/culture)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/slant? yeasts/sample-yeast)))
+    (is (boolean? (sut/slant? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :form"
+                  (sut/slant? (dissoc yeasts/sample-yeast :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :form"
+                   (sut/slant? (dissoc yeasts/sample-yeast :form)))))))
+
+
+(deftest culture?-test
+  (testing "A yeast with a `:form` matching `\"culture\"` returns true"
+    (is (true? (sut/culture? (assoc yeasts/sample-yeast :form "culture"))))
+    (is (true? (sut/culture? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/culture)))))
+  (testing "A yeast with a `:form` not matching `\"culture\"` returns false"
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast :form "liquid"))))
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast :form "dry"))))
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast :form "slant"))))
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/liquid))))
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/dry))))
+    (is (false? (sut/culture? (assoc yeasts/sample-yeast cbf-yeasts/form cbf-yeasts/slant)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/culture? yeasts/sample-yeast)))
+    (is (boolean? (sut/culture? (yeasts/generate-yeast)))))
+  (testing "If the yeast is missing `:form`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :form"
+                  (sut/culture? (dissoc yeasts/sample-yeast :form)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :form"
+                   (sut/culture? (dissoc yeasts/sample-yeast :form)))))))
+
+
+;;
+;; :flocculation function tests
+;;
+
+(deftest low-flocculation?-test
+  (testing "A yeast with a `:flocculation` matching `\"culture\"` returns true"
+    (is (true? (sut/low-flocculation? (assoc yeasts/sample-yeast :flocculation "low"))))
+    (is (true? (sut/low-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/low)))))
+  (testing "A yeast with a `:flocculation` not matching `\"culture\"` returns false"
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast :flocculation "medium"))))
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast :flocculation "high"))))
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast :flocculation "very high"))))
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/medium))))
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/high))))
+    (is (false? (sut/low-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/very-high)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/low-flocculation? (assoc yeasts/sample-yeast :flocculation (yeasts/random-flocculation)))))
+    (is (boolean? (sut/low-flocculation? (assoc (yeasts/generate-yeast) :flocculation (yeasts/random-flocculation))))))
+  (testing "If the yeast is missing `:flocculation`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :flocculation"
+                  (sut/low-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :flocculation"
+                   (sut/low-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))))
+
+
+(deftest medium-flocculation?-test
+  (testing "A yeast with a `:flocculation` matching `\"culture\"` returns true"
+    (is (true? (sut/medium-flocculation? (assoc yeasts/sample-yeast :flocculation "medium"))))
+    (is (true? (sut/medium-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/medium)))))
+  (testing "A yeast with a `:flocculation` not matching `\"culture\"` returns false"
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast :flocculation "low"))))
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast :flocculation "high"))))
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast :flocculation "very high"))))
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/low))))
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/high))))
+    (is (false? (sut/medium-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/very-high)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/medium-flocculation? (assoc yeasts/sample-yeast :flocculation (yeasts/random-flocculation)))))
+    (is (boolean? (sut/medium-flocculation? (assoc (yeasts/generate-yeast) :flocculation (yeasts/random-flocculation))))))
+  (testing "If the yeast is missing `:flocculation`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :flocculation"
+                  (sut/medium-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :flocculation"
+                   (sut/medium-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))))
+
+
+(deftest high-flocculation?-test
+  (testing "A yeast with a `:flocculation` matching `\"culture\"` returns true"
+    (is (true? (sut/high-flocculation? (assoc yeasts/sample-yeast :flocculation "high"))))
+    (is (true? (sut/high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/high)))))
+  (testing "A yeast with a `:flocculation` not matching `\"culture\"` returns false"
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast :flocculation "low"))))
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast :flocculation "medium"))))
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast :flocculation "very high"))))
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/low))))
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/medium))))
+    (is (false? (sut/high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/very-high)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/high-flocculation? (assoc yeasts/sample-yeast :flocculation (yeasts/random-flocculation)))))
+    (is (boolean? (sut/high-flocculation? (assoc (yeasts/generate-yeast) :flocculation (yeasts/random-flocculation))))))
+  (testing "If the yeast is missing `:flocculation`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :flocculation"
+                  (sut/high-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :flocculation"
+                   (sut/high-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))))
+
+
+(deftest very-high-flocculation?-test
+  (testing "A yeast with a `:flocculation` matching `\"culture\"` returns true"
+    (is (true? (sut/very-high-flocculation? (assoc yeasts/sample-yeast :flocculation "very high"))))
+    (is (true? (sut/very-high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/very-high)))))
+  (testing "A yeast with a `:flocculation` not matching `\"culture\"` returns false"
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast :flocculation "low"))))
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast :flocculation "medium"))))
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast :flocculation "high"))))
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/low))))
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/medium))))
+    (is (false? (sut/very-high-flocculation? (assoc yeasts/sample-yeast cbf-yeasts/flocculation cbf-yeasts/high)))))
+  (testing "This is a function from a yeast to a boolean"
+    (is (boolean? (sut/very-high-flocculation? (assoc yeasts/sample-yeast :flocculation (yeasts/random-flocculation)))))
+    (is (boolean? (sut/very-high-flocculation? (assoc (yeasts/generate-yeast) :flocculation (yeasts/random-flocculation))))))
+  (testing "If the yeast is missing `:flocculation`, throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception
+                                  #"Yeast :flocculation"
+                  (sut/very-high-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))
+    #?(:cljs (is (thrown-with-msg? js/Error
+                                   #"Yeast :flocculation"
+                   (sut/very-high-flocculation? (dissoc yeasts/sample-yeast :flocculation)))))))

--- a/test/brewtility/runner.cljs
+++ b/test/brewtility/runner.cljs
@@ -11,6 +11,16 @@
             [brewtility.data.waters]
             [brewtility.data.yeasts]
             [brewtility.precision-test]
+            [brewtility.predicates.equipment-test]
+            [brewtility.predicates.fermentables-test]
+            [brewtility.predicates.hops-test]
+            [brewtility.predicates.impl-test]
+            [brewtility.predicates.mash-test]
+            [brewtility.predicates.miscs-test]
+            [brewtility.predicates.recipes-test]
+            [brewtility.predicates.styles-test]
+            [brewtility.predicates.waters-test]
+            [brewtility.predicates.yeasts-test]
             [brewtility.units-test]
             [brewtility.wrapping-test]
             [doo.runner :refer-macros [doo-tests]]))
@@ -28,5 +38,15 @@
            'brewtility.data.waters
            'brewtility.data.yeasts
            'brewtility.precision-test
+           'brewtility.predicates.equipment-test
+           'brewtility.predicates.fermentables-test
+           'brewtility.predicates.hops-test
+           'brewtility.predicates.impl-test
+           'brewtility.predicates.mash-test
+           'brewtility.predicates.miscs-test
+           'brewtility.predicates.recipes-test
+           'brewtility.predicates.styles-test
+           'brewtility.predicates.waters-test
+           'brewtility.predicates.yeasts-test
            'brewtility.units-test
            'brewtility.wrapping-test)

--- a/test/brewtility/units_test.cljc
+++ b/test/brewtility/units_test.cljc
@@ -1,8 +1,8 @@
 (ns brewtility.units-test
-  (:require [brewtility.units :as sut]
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
             [brewtility.precision :as bp]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+            [brewtility.units :as sut]))
 
 
 (deftest convert-volume-test

--- a/test/brewtility/wrapping_test.cljc
+++ b/test/brewtility/wrapping_test.cljc
@@ -1,5 +1,7 @@
 (ns brewtility.wrapping-test
-  (:require [brewtility.data.equipment :as equipment.data]
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [brewtility.data.equipment :as equipment.data]
             [brewtility.data.fermentables :as fermentables.data]
             [brewtility.data.hops :as hops.data]
             [brewtility.data.mash :as mash.data]
@@ -18,9 +20,7 @@
             [common-beer-format.recipes :as recipes.format]
             [common-beer-format.styles :as styles.format]
             [common-beer-format.waters :as waters.format]
-            [common-beer-format.yeasts :as yeasts.format]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+            [common-beer-format.yeasts :as yeasts.format]))
 
 
 (deftest equipment-tests


### PR DESCRIPTION
# Proposed Changes

- Additions: Predicate functions for common assertions against common-beer-format types, a calculation function to derive the volume of wort at the start of the boil.
- Updates: `com.wallbrew/spoon` is now a production dependency of `brewtility`, introduced missing `defn` metadata tags in the `calculation` namespace.
- Deletions:

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
