### PR TITLE
Add calculation exceptions

### DIFF
--- a/.sealog/changes/2-2-1.edn
+++ b/.sealog/changes/2-2-1.edn
@@ -1,0 +1,12 @@
+{:version      {:major 2
+                :minor 2
+                :patch 1}
+ :version-type :semver3
+ :changes      {:added      []
+                :changed    []
+                :deprecated []
+                :removed    []
+                :fixed      ["`brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values."
+                             "`brewtility.calculations` functions now thros an explicit exception when passed non-numeric values."]
+                :security   []}
+ :timestamp    "2024-10-03T01:33:51.309111782Z"}

--- a/.sealog/changes/2-2-1.edn
+++ b/.sealog/changes/2-2-1.edn
@@ -7,6 +7,6 @@
                 :deprecated []
                 :removed    []
                 :fixed      ["`brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values."
-                             "`brewtility.calculations` functions now thros an explicit exception when passed non-numeric values."]
+                             "`brewtility.calculations` functions now throws an explicit exception when passed non-numeric values."]
                 :security   []}
  :timestamp    "2024-10-03T01:33:51.309111782Z"}

--- a/.sealog/changes/2-2-1.edn
+++ b/.sealog/changes/2-2-1.edn
@@ -7,6 +7,6 @@
                 :deprecated []
                 :removed    []
                 :fixed      ["`brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values."
-                             "`brewtility.calculations` functions now throws an explicit exception when passed non-numeric values."]
+                             "`brewtility.calculations` functions now throw an explicit exception when passed non-numeric values."]
                 :security   []}
  :timestamp    "2024-10-03T01:33:51.309111782Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * Fixed
   * `brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values.
-  * `brewtility.calculations` functions now throws an explicit exception when passed non-numeric values.
+  * `brewtility.calculations` functions now throw an explicit exception when passed non-numeric values.
 
 ## 2.2.0 - 2024-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [2.2.1 - 2024-10-03](#221---2024-10-03)
 * [2.2.0 - 2024-09-21](#220---2024-09-21)
 * [2.1.0 - 2024-09-20](#210---2024-09-20)
 * [2.0.1 - 2024-03-11](#201---2024-03-11)
@@ -16,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [1.2.0 - 2022-07-10](#120---2022-07-10)
 * [1.1.0 - 2020-08-15](#110---2020-08-15)
 * [1.0.0 - 2020-07-19](#100---2020-07-19)
+
+## 2.2.1 - 2024-10-03
+
+* Fixed
+  * `brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values.
+  * `brewtility.calculations` functions now thros an explicit exception when passed non-numeric values.
 
 ## 2.2.0 - 2024-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * Fixed
   * `brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values.
-  * `brewtility.calculations` functions now thros an explicit exception when passed non-numeric values.
+  * `brewtility.calculations` functions now throws an explicit exception when passed non-numeric values.
 
 ## 2.2.0 - 2024-09-21
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+.PHONY: version/major version/minor version/patch changelog/render tests/all tests/clojure tests/clojurescript
 MAKE = make
 
 # These are the locations of the directories we'll use
@@ -37,3 +37,15 @@ version/patch:
 changelog/render:
 	$(info Rendering CHANGELOG...)
 	@ lein sealog render
+
+tests/all: tests/clojure tests/clojurescript
+
+tests/clojure:
+	$(info Running Clojure tests...)
+	@ lein test
+
+tests/clojurescript:
+	$(info Running ClojureScript tests...)
+	@ lein clean
+	@ lein cljsbuild once test
+	@ lein doo once

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewtility",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brewtility",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "devDependencies": {
         "karma": "^6.3.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewtility",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Utility functions for all of your brewing needs.",
   "main": "index.js",
   "directories": {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>brewtility</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <name>brewtility</name>
   <description>Utility functions for all of your brewing needs.</description>
   <url>https://github.com/Wall-Brew-Co/brewtility</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/brewtility</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/brewtility.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/brewtility.git</developerConnection>
-    <tag>d9766931447f393e296a2467c8786cd972dd52f6</tag>
+    <tag>4f58a239c9f5b10766983328cdd94fd857c30635</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/brewtility "2.2.0"
+(defproject com.wallbrew/brewtility "2.2.1"
   :description "Utility functions for all of your brewing needs."
   :url "https://github.com/Wall-Brew-Co/brewtility"
   :license {:name         "MIT"

--- a/src/brewtility/precision.cljc
+++ b/src/brewtility/precision.cljc
@@ -25,10 +25,10 @@
    :see-also ["->1dp" "->2dp" "->3dp"]}
   [^double x ^long num-decimals]
   (double
-   #?(:clj (.setScale (bigdec x) num-decimals RoundingMode/HALF_UP)
-      :cljs (let [denominator (Math/pow 10.0 (double num-decimals))
-                  numerator   (Math/round (* x denominator))]
-              (/ numerator denominator)))))
+    #?(:clj (.setScale (bigdec x) num-decimals RoundingMode/HALF_UP)
+       :cljs (let [denominator (Math/pow 10.0 (double num-decimals))
+                   numerator   (Math/round (* x denominator))]
+               (/ numerator denominator)))))
 
 
 (defn ->1dp

--- a/src/brewtility/precision.cljc
+++ b/src/brewtility/precision.cljc
@@ -8,20 +8,27 @@
   "Determine if `n2` approximates `n1` within `variance` percent."
   {:added "1.0"}
   [n1 n2 variance]
-  (let [upper-bound (* n1 (+ 1.0 variance))
-        lower-bound (* n1 (- 1.0 variance))]
-    (<= lower-bound n2 upper-bound)))
+  (if (and (number? n1)
+           (number? n2)
+           (number? variance))
+    (let [upper-bound (* n1 (+ 1.0 variance))
+          lower-bound (* n1 (- 1.0 variance))]
+      (<= lower-bound n2 upper-bound))
+    (throw (ex-info "Cannot approximate using non-numeric values" {:n1       n1
+                                                                   :n2       n2
+                                                                   :variance variance}))))
 
 
 (defn ->precision
   "Given a decimal `x` and the number of decimal places, returns that number rounded to `num-decimals` precision."
-  {:added "1.0"}
+  {:added    "1.0"
+   :see-also ["->1dp" "->2dp" "->3dp"]}
   [^double x ^long num-decimals]
   (double
-    #?(:clj (.setScale (bigdec x) num-decimals RoundingMode/HALF_UP)
-       :cljs (let [denominator (Math/pow 10.0 (double num-decimals))
-                   numerator   (Math/round (* x denominator))]
-               (/ numerator denominator)))))
+   #?(:clj (.setScale (bigdec x) num-decimals RoundingMode/HALF_UP)
+      :cljs (let [denominator (Math/pow 10.0 (double num-decimals))
+                  numerator   (Math/round (* x denominator))]
+              (/ numerator denominator)))))
 
 
 (defn ->1dp

--- a/src/brewtility/predicates/options.cljc
+++ b/src/brewtility/predicates/options.cljc
@@ -1,5 +1,6 @@
 (ns brewtility.predicates.options
   "A namespace of static symbolic keywords and values used in the option maps throughout brewtility.
+
    Implemented as part of the Symbolic Keyword pattern."
   {:added "2.2"})
 
@@ -8,5 +9,6 @@
 
 (def uppercase?
   "A keyword used to determine if a string comparison should be cast to UPPERCASE instead of lowercase.
+
    This option is inherited from the functions in `com.wallbrew.spoon.string`"
   :uppercase?)

--- a/src/brewtility/units.cljc
+++ b/src/brewtility/units.cljc
@@ -3,6 +3,7 @@
 
    Currently, brewtility supports the following types of measurements:
 
+     - [Alcohol Content](https://en.wikipedia.org/wiki/Alcohol_by_volume)
      - [Bitterness](https://en.wikipedia.org/wiki/Beer_measurement#Bitterness)
      - [Carbonation](https://en.wikipedia.org/wiki/Carbon_dioxide#Beverages)
      - [Color](https://en.wikipedia.org/wiki/Beer_measurement#Colour)
@@ -64,7 +65,7 @@
    (convert measurement-type measurement source-units target-units {}))
   ([measurement-type measurement source-units target-units {:keys [precision]}]
    (let [converted-value (case measurement-type
-                           :alcohol-content (alcohol-content/convert measurement source-units target-units)
+                           :alcohol-content  (alcohol-content/convert measurement source-units target-units)
                            :bitterness       (bitterness/convert measurement source-units target-units)
                            :carbonation      (carbonation/convert measurement source-units target-units)
                            :color            (color/convert measurement source-units target-units)

--- a/src/brewtility/units/color.cljc
+++ b/src/brewtility/units/color.cljc
@@ -40,19 +40,16 @@
 ;;
 (def srm-1
   "An SRM of 1 mapped to an RGBa color code."
-
   "rgba(255,230,153,1)")
 
 
 (def srm-2
   "An SRM of 2 mapped to an RGBa color code."
-
   "rgba(255,216,120,1)")
 
 
 (def srm-3
   "An SRM of 3 mapped to an RGBa color code."
-
   "rgba(255,202,90,1)")
 
 

--- a/test/brewtility/precision_test.cljc
+++ b/test/brewtility/precision_test.cljc
@@ -1,14 +1,26 @@
 (ns brewtility.precision-test
-  (:require #? (:clj [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test :refer-macros [deftest is testing]])
-            [brewtility.precision :as sut]))
+  (:require [brewtility.precision :as sut]
+            [clojure.test :refer [deftest is testing]]))
 
 
 (deftest approximates?-test
   (testing "Ensure approximation works as expected"
-    (is (true? (sut/approximates? 100 100 0.00001)))
-    (is (true? (sut/approximates? 100 90 0.1)))
-    (is (false? (sut/approximates? 100 90 0.01)))))
+    (is (true? (sut/approximates? 100 100 0.00001))
+        "Equal numbers will always return true")
+    (is (let [r-int (rand-int 1000000)]
+          (true? (sut/approximates? r-int r-int 0.00001)))
+        "Equal integers will always return true")
+    (is (true? (sut/approximates? 100 90 0.1))
+        "90 is within 10% of 100")
+    (is (false? (sut/approximates? 100 90 0.01))
+        "90 is not within 1% of 100"))
+  (testing "Ensure that non-numeric values throw an exception"
+    #?(:clj (is (thrown-with-msg? Exception #"Cannot approximate using non-numeric values" (sut/approximates? nil 100 0.00001))))
+    #?(:clj (is (thrown-with-msg? Exception #"Cannot approximate using non-numeric values" (sut/approximates? 100 nil 0.00001))))
+    #?(:clj (is (thrown-with-msg? Exception #"Cannot approximate using non-numeric values" (sut/approximates? 100 100 nil))))
+    #?(:cljs (is (thrown-with-msg? js/Error #"Cannot approximate using non-numeric values" (sut/approximates? nil 100 0.00001))))
+    #?(:cljs (is (thrown-with-msg? js/Error #"Cannot approximate using non-numeric values" (sut/approximates? 100 nil 0.00001))))
+    #?(:cljs (is (thrown-with-msg? js/Error #"Cannot approximate using non-numeric values" (sut/approximates? 100 100 nil))))))
 
 
 (deftest ->1dp-test


### PR DESCRIPTION
# Proposed Changes

- Additions:
- Updates:
  - `brewtility.precision/approximates?` now throws an explicit exception when passed non-numeric values.
  - `brewtility.calculations` functions now throw an explicit exception when passed non-numeric values.
- Deletions:

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] Write new tests for the changed functionality
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
